### PR TITLE
Double file release

### DIFF
--- a/src/sheerwater_benchmarking/utils/caching.py
+++ b/src/sheerwater_benchmarking/utils/caching.py
@@ -117,7 +117,13 @@ def cacheable(data_type, immutable_args, timeseries=False, cache=True):
                     if data_type == 'array':
                         print(f"Autocaching result for {cache_path}.")
                         if isinstance(ds, xr.Dataset):
-                            ds.chunk(chunks="auto").to_zarr(store=cache_map, mode='w')
+                            try:
+                                ds.chunk(chunks="auto").to_zarr(store=cache_map, mode='w')
+                            except FileNotFoundError:
+                                # TODO: sometimes getting a dobule release error on the temp file
+                                # Temporary fix to catch and pass; the zarr write seems to work
+                                pass
+                            
 
             if filepath_only:
                 return cache_map


### PR DESCRIPTION
@adkinsjd, I'm having a problem where, when I run my dask-based multiple ecmwf funtion, I'm getting a double release on the temp file when we zarr cache? Exception: "FileNotFoundError(2, 'No such file or directory')

We do do:
1. Write temp nc file
2. Open ds with xarray from nc file
3. Delete nc file
4. Write ds to zarr cache

I thought the problem might be some lazy loading in step (2), so I tried adding a `ds.close()` between 2&4, but it didn't fix. 

```
Autocaching result for gs://sheerwater-datalake/caches/single_iri_ecmwf/forecast_global1_5_control_2015-06-22_precip.zarr.
2024-08-09 00:03:53,137 - distributed.worker - WARNING - Compute Failed
Key:       ('xarray-precip-65fb32d64028a35c56a11f9d6d85041d', 0, 0, 0, 0)
State:     executing
Function:  getter
args:      (ImplicitToExplicitIndexingAdapter(array=MemoryCachedArray(array=CopyOnWriteArray(array=LazilyIndexedArray(array=<xarray.backends.netCDF4_.NetCDF4ArrayWrapper object at 0x28cb34d80>, key=BasicIndexer((slice(None, None, None), slice(None, None, None), slice(None, None, None), slice(None, None, None))))))), (slice(0, 46, None), slice(0, 1, None), slice(0, 121, None), slice(0, 240, None)))
kwargs:    {}
Exception: "FileNotFoundError(2, 'No such file or directory')"
Traceback: '  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/dask/array/core.py", line 118, in getter\n    c = np.asarray(c)\n        ^^^^^^^^^^^^^\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/core/indexing.py", line 573, in __array__\n    return np.asarray(self.get_duck_array(), dtype=dtype)\n                      ^^^^^^^^^^^^^^^^^^^^^\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/core/indexing.py", line 576, in get_duck_array\n    return self.array.get_duck_array()\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/core/indexing.py", line 836, in get_duck_array\n    self._ensure_cached()\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/core/indexing.py", line 830, in _ensure_cached\n    self.array = as_indexable(self.array.get_duck_array())\n                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/core/indexing.py", line 787, in get_duck_array\n    return self.array.get_duck_array()\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/core/indexing.py", line 650, in get_duck_array\n    array = self.array[self.key]\n            ~~~~~~~~~~^^^^^^^^^^\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/backends/netCDF4_.py", line 100, in __getitem__\n    return indexing.explicit_indexing_adapter(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/core/indexing.py", line 1014, in explicit_indexing_adapter\n    result = raw_indexing_method(raw_key.tuple)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/backends/netCDF4_.py", line 112, in _getitem\n    original_array = self.get_array(needs_lock=False)\n                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/backends/netCDF4_.py", line 91, in get_array\n    ds = self.datastore._acquire(needs_lock)\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/backends/netCDF4_.py", line 411, in _acquire\n    with self._manager.acquire_context(needs_lock) as root:\n  File "/Users/avocet/.rye/py/cpython@3.12.3/lib/python3.12/contextlib.py", line 137, in __enter__\n    return next(self.gen)\n           ^^^^^^^^^^^^^^\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/backends/file_manager.py", line 199, in acquire_context\n    file, cached = self._acquire_with_cache_info(needs_lock)\n                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/Users/avocet/content/subseasonal_world/.venv/lib/python3.12/site-packages/xarray/backends/file_manager.py", line 217, in _acquire_with_cache_info\n    file = self._opener(*self._args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "src/netCDF4/_netCDF4.pyx", line 2470, in netCDF4._netCDF4.Dataset.__init__\n  File "src/netCDF4/_netCDF4.pyx", line 2107, in netCDF4._netCDF4._ensure_nc_success\n'
```