### PR TITLE
Small fixes: wrapped chuking, parameter handling, additional features

### DIFF
--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -136,7 +136,7 @@ def cacheable(data_type, cache_args, timeseries=None):
                         # If rechunk is passed then check to see if the rechunk array matches chunking. If not then rechunk
                         if rechunk:
                             # Get the chunks for the dataset
-                            ds_chunks = {dim: ds1.chunks[dim][0] for dim in ds1.chunks}
+                            ds_chunks = {dim: ds.chunks[dim][0] for dim in ds.chunks}
 
                             # Compare the dict to the rechunk dict
                             print(ds_chunks)

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -173,8 +173,7 @@ def cacheable(data_type, cache_args, timeseries=None):
                     elif data_type == 'array':
                         write = False
                         if fs.exists(cache_path) and not force_overwrite:
-                            inp = input(f'A cache already exists at '
-                                        f'{cache_path}. Are you sure you want to overwrite it? (y/n)')
+                            inp = input(f'A cache already exists at {cache_path}. Are you sure you want to overwrite it? (y/n)')
                             if inp == 'y' or inp == 'Y':
                                 write = True
                         else:

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -9,8 +9,18 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def cacheable(data_type, cache_args, timeseries=None, cache=True):
-    """Decorator for caching function results."""
+def cacheable(data_type, cache_args, timeseries=None, cache=True, force_overwrite=False):
+    """Decorator for caching function results.
+
+    Args:
+        data_type (str): The type of data being cached. Currently only 'array' is supported.
+        cache_args (list): The arguments to use as the cache key.
+        timeseries (str): The name of the time series dimension in the cached array. If not a 
+            time series, set to None (default).
+        cache (bool): Whether to cache the result.
+        force_overwrite (bool): Whether to overwrite the cache forecable on recompute if it 
+            already exists (if False, will prompt the user before overwriting).
+    """
     def create_cacheable(func):
         def wrapper(*args, **kwargs):
             # Calculate the appropriate cache key
@@ -146,7 +156,7 @@ def cacheable(data_type, cache_args, timeseries=None, cache=True):
                             return None
                     elif data_type == 'array':
                         write = False
-                        if fs.exists(cache_path):
+                        if fs.exists(cache_path) and not force_overwrite:
                             inp = input(f'A cache already exists at {
                                         cache_path}. Are you sure you want to overwrite it? (y/n)')
                             if inp == 'y' or inp == 'Y':

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -87,8 +87,7 @@ def cacheable(data_type, cache_args, timeseries=False, cache=True):
                 raise ValueError("Caching currently only supports the 'array' datatype")
 
             # Check to see if the cache exists for this key
-            fs = gcsfs.GCSFileSystem(
-                project='sheerwater', token='google_default')
+            fs = gcsfs.GCSFileSystem(project='sheerwater', token='google_default')
             cache_map = fs.get_mapper(cache_path)
 
             ds = None
@@ -129,14 +128,11 @@ def cacheable(data_type, cache_args, timeseries=False, cache=True):
 
             if compute_result:
                 if recompute:
-                    print(f"Recompute for {
-                          cache_path} requested. Not checking for cached result.")
+                    print(f"Recompute for {cache_path} requested. Not checking for cached result.")
                 elif not cache:
-                    print(
-                        f"{func.__name__} not a cacheable function. Recomputing result.")
+                    print(f"{func.__name__} not a cacheable function. Recomputing result.")
                 else:
-                    print(f"Cache doesn't exist for {
-                          cache_path}. Running function")
+                    print(f"Cache doesn't exist for {cache_path}. Running function")
 
                 ##### IF NOT EXISTS ######
                 ds = func(*args, **kwargs)

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -181,6 +181,9 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
                                     "Rechunk was passed and cached chunks do not match rechunk request. Performing rechunking")
 
                                 # write to a temp cache map
+                                # writing to temp cache is necessary because if you overwrite
+                                # the original cache map it will write it before reading the
+                                # data leading to corruption.
                                 temp_cache_path = 'gs://sheerwater-datalake/caches/temp/' + cache_key
                                 temp_cache_map = fs.get_mapper(temp_cache_path)
 

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -53,7 +53,7 @@ def cacheable(data_type, cache_args, timeseries=None):
         def wrapper(*args, **kwargs):
             # Calculate the appropriate cache key
             filepath_only, recompute, cache, validate_cache_timeseries, \
-                force_overwrite, retry_null_cache = get_cache_args(
+                force_overwrite, retry_null_cache, rechunk = get_cache_args(
                     kwargs, cache_kwargs)
 
             params = signature(func).parameters

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -87,7 +87,8 @@ def cacheable(data_type, cache_args, timeseries=False, cache=True):
                 raise ValueError("Caching currently only supports the 'array' datatype")
 
             # Check to see if the cache exists for this key
-            fs = gcsfs.GCSFileSystem(project='sheerwater', token='google_default')
+            fs = gcsfs.GCSFileSystem(
+                project='sheerwater', token='google_default')
             cache_map = fs.get_mapper(cache_path)
 
             ds = None
@@ -128,11 +129,14 @@ def cacheable(data_type, cache_args, timeseries=False, cache=True):
 
             if compute_result:
                 if recompute:
-                    print(f"Recompute for {cache_path} requested. Not checking for cached result.")
+                    print(f"Recompute for {
+                          cache_path} requested. Not checking for cached result.")
                 elif not cache:
-                    print(f"{func.__name__} not a cacheable function. Recomputing result.")
+                    print(
+                        f"{func.__name__} not a cacheable function. Recomputing result.")
                 else:
-                    print(f"Cache doesn't exist for {cache_path}. Running function")
+                    print(f"Cache doesn't exist for {
+                          cache_path}. Running function")
 
                 ##### IF NOT EXISTS ######
                 ds = func(*args, **kwargs)
@@ -157,7 +161,11 @@ def cacheable(data_type, cache_args, timeseries=False, cache=True):
                         if write:
                             print(f"Caching result for {cache_path}.")
                             if isinstance(ds, xr.Dataset):
-                                ds.chunk(chunks="auto").to_zarr(store=cache_map, mode='w')
+                                if hasattr(ds, '_sw_chunk_dict'):
+                                    chunks = ds._sw_chunk_dict
+                                else:
+                                    chunks = 'auto'
+                                ds.chunk(chunks=chunks).to_zarr(store=cache_map, mode='w')
                             else:
                                 raise RuntimeError(
                                     f"Array datatypes must return xarray datasets or None instead of {type(ds)}")

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -257,9 +257,15 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
 
                                     chunks = chunking
                                     ds.chunk(chunks=chunks).to_zarr(store=cache_map, mode='w')
+
+                                    # Reopen the dataset to truncate the computational path
+                                    ds = xr.open_dataset(cache_map, engine='zarr', chunks={})
                                 else:
                                     chunks = 'auto'
                                     ds.chunk(chunks=chunks).to_zarr(store=cache_map, mode='w')
+
+                                    # Reopen the dataset to truncate the computational path
+                                    ds = xr.open_dataset(cache_map, engine='zarr', chunks={})
                             else:
                                 raise RuntimeError(
                                     f"Array datatypes must return xarray datasets or None instead of {type(ds)}")

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -32,7 +32,6 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
         "force_overwrite": False,
         "retry_null_cache": False,
     }
-
     """Decorator for caching function results.
 
     Args:
@@ -65,8 +64,8 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
             start_time = None
             end_time = None
             if timeseries is not None:
-                if not isinstance(timeseries, list):
-                    timeseries = [timeseries]
+                # Convert to a list if not
+                tl = [timeseries if isinstance(timeseries, list) else [timeseries]]
 
                 if 'start_time' in cache_args or 'end_time' in cache_args:
                     raise ValueError(
@@ -187,7 +186,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
 
                         if validate_cache_timeseries and timeseries is not None:
                             # Check to see if the dataset extends roughly the full time series set
-                            match_time = [t for t in timeseries if t in ds.dims]
+                            match_time = [t for t in tl if t in ds.dims]
                             if len(match_time) == 0:
                                 raise RuntimeError("Timeseries array functions must return a time dimension for slicing. "
                                                    "This could be an invalid cache. Try running with recompute=True to reset the cache.")
@@ -280,7 +279,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
             else:
                 # Do the time series filtering
                 if timeseries is not None:
-                    match_time = [t for t in timeseries if t in ds.dims]
+                    match_time = [t for t in tl if t in ds.dims]
                     if len(match_time) == 0:
                         raise RuntimeError(
                             "Timeseries array must return a 'time' dimension for slicing.")

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -161,8 +161,8 @@ def cacheable(data_type, cache_args, timeseries=False, cache=True):
                         if write:
                             print(f"Caching result for {cache_path}.")
                             if isinstance(ds, xr.Dataset):
-                                if hasattr(ds, '_sw_chunk_dict'):
-                                    chunks = ds._sw_chunk_dict
+                                if hasattr(ds, '_chunk_dict'):
+                                    chunks = ds._chunk_dict
                                 else:
                                     chunks = 'auto'
                                 ds.chunk(chunks=chunks).to_zarr(store=cache_map, mode='w')

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -21,7 +21,7 @@ def get_cache_args(kwargs, cache_kwargs):
             cache_args.append(cache_kwargs[k])
     return cache_args
 
-def prune_chunking_dimensions(ds, chunking)
+def prune_chunking_dimensions(ds, chunking):
     # Get the chunks for the dataset
     ds_chunks = {dim: ds.chunks[dim][0] for dim in ds.chunks}
 

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -65,7 +65,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
             end_time = None
             if timeseries is not None:
                 # Convert to a list if not
-                tl = [timeseries if isinstance(timeseries, list) else [timeseries]]
+                tl = timeseries if isinstance(timeseries, list) else [timeseries]
 
                 if 'start_time' in cache_args or 'end_time' in cache_args:
                     raise ValueError(

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -9,7 +9,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def cacheable(data_type, cache_args, timeseries=None, cache=True, force_overwrite=False):
+def cacheable(data_type, cache_args, timeseries=None, cache=True, force_overwrite=False,
+              retry_null_cache=False):
     """Decorator for caching function results.
 
     Args:
@@ -20,6 +21,8 @@ def cacheable(data_type, cache_args, timeseries=None, cache=True, force_overwrit
         cache (bool): Whether to cache the result.
         force_overwrite (bool): Whether to overwrite the cache forecable on recompute if it 
             already exists (if False, will prompt the user before overwriting).
+        retry_null_cache (bool): If True, ignore the null caches and attempts to recompute
+            result for null values. If False (default), will return None for null caches.
     """
     def create_cacheable(func):
         def wrapper(*args, **kwargs):
@@ -132,7 +135,7 @@ def cacheable(data_type, cache_args, timeseries=None, cache=True, force_overwrit
                             compute_result = False
                 else:
                     print("Auto caching currently only supports array types")
-            elif fs.exists(null_path) and not recompute and cache:
+            elif fs.exists(null_path) and not recompute and cache and not retry_null_cache:
                 print(f"Found null cache for {null_path}. Skipping computation.")
                 return None
 

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -263,7 +263,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
                                     # If we aren't doing auto chunking delete the encoding chunks
                                     ds = drop_encoded_chunks(ds)
 
-                                    chunking = prune_chunking_dimension(ds, chunking)
+                                    chunking = prune_chunking_dimensions(ds, chunking)
 
                                     ds.chunk(chunks=chunking).to_zarr(store=cache_map, mode='w')
 

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -137,16 +137,16 @@ def cacheable(data_type, cache_args, timeseries=None):
                             # Get the chunks for the zeroth variable
                             ds_chunks = None
                             for var in ds.data_vars:
-                                 ds_chunks = ds[var].chunks
-                                 break
+                                ds_chunks = ds[var].chunks
+                                break
 
-                             # Compare the dict to the rechunk dict
-                             if ds_chunks != rechunk:
-                                 print("Rechunk was passed and cached chunks do not match rechunk request. Performing recunking")
-                                 with dask.config.set({"array.slicing.split_large_chunks": False}):
-                                     ds.chunk(chunks=rechunk).to_zarr(store=cache_map, mode='w')
-                             else:
-                                 print("Requested chunks already match rechunk.")
+                            # Compare the dict to the rechunk dict
+                            if ds_chunks != rechunk:
+                                print("Rechunk was passed and cached chunks do not match rechunk request. Performing recunking")
+                                with dask.config.set({"array.slicing.split_large_chunks": False}):
+                                    ds.chunk(chunks=rechunk).to_zarr(store=cache_map, mode='w')
+                            else:
+                                print("Requested chunks already match rechunk.")
 
 
 

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -155,6 +155,7 @@ def cacheable(data_type, cache_args, timeseries=None):
                                 ds.chunk(chunks=rechunk).to_zarr(store=temp_cache_map, mode='w')
 
                                 # move to a permanent cache map
+                                fs.rm(cache_path, recursive=True)
                                 fs.mv(temp_cache_path, cache_path, recursive=True)
 
                                 # Reopen the dataset

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -126,7 +126,7 @@ def cacheable(data_type, cache_args, timeseries=None):
                         return cache_map
                     else:
                         print(f"Opening cache {cache_path}")
-                        ds = xr.open_dataset(cache_map, engine='zarr')
+                        ds = xr.open_dataset(cache_map, engine='zarr', chunks={})
 
                         if validate_cache_timeseries and timeseries is not None:
                             # Check to see if the dataset extends roughly the full time series set

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -157,8 +157,8 @@ def cacheable(data_type, cache_args, timeseries=None, cache=True, force_overwrit
                     elif data_type == 'array':
                         write = False
                         if fs.exists(cache_path) and not force_overwrite:
-                            inp = input(f'A cache already exists at {
-                                        cache_path}. Are you sure you want to overwrite it? (y/n)')
+                            inp = input(f'A cache already exists at '
+                                        f'{cache_path}. Are you sure you want to overwrite it? (y/n)')
                             if inp == 'y' or inp == 'Y':
                                 write = True
                         else:

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -155,7 +155,7 @@ def cacheable(data_type, cache_args, timeseries=None):
                                 ds.chunk(chunks=rechunk).to_zarr(store=temp_cache_map, mode='w')
 
                                 # move to a permanent cache map
-                                fs.mv(temp_cache_path, cache_path)
+                                fs.mv(temp_cache_path, cache_path, recusrive=True)
 
                                 # Reopen the dataset
                                 ds = xr.open_dataset(cache_map, engine='zarr', chunks={})

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -144,9 +144,13 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
                             ds_chunks = {dim: ds.chunks[dim][0] for dim in ds.chunks}
 
                             # Drop any dimensions that don't exist in the ds_chunks
+                            dims_to_drop = []
                             for dim in chunking:
                                 if dim not in ds_chunks:
-                                    del chunking[dim]
+                                    dims_to_drop.append(dim)
+
+                            for dim in dims_to_drop:
+                                del chunking[dim]
 
                             # Compare the dict to the rechunk dict
                             if ds_chunks != chunking:
@@ -239,9 +243,13 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
                                     ds_chunks = {dim: ds.chunks[dim][0] for dim in ds.chunks}
 
                                     # Drop any dimensions that don't exist in the ds_chunks
+                                    dims_to_drop = []
                                     for dim in chunking:
                                         if dim not in ds_chunks:
-                                            del chunking[dim]
+                                            dims_to_drop.append(dim)
+
+                                    for dim in dims_to_drop:
+                                        del chunking[dim]
 
                                     chunks = chunking
                                     ds.chunk(chunks=chunks).to_zarr(store=cache_map, mode='w')

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -1,4 +1,5 @@
 """Automated dataframe caching utilities."""
+import dask
 import gcsfs
 import xarray as xr
 import pandas

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -167,7 +167,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
                                 ds.chunk(chunks=chunking).to_zarr(store=temp_cache_map, mode='w')
 
                                 # move to a permanent cache map
-                                if fs.exists(cache_path)
+                                if fs.exists(cache_path):
                                     print(f"Deleting {cache_path} to replace.")
                                     fs.rm(cache_path, recursive=True)
                                     print(f"Confirm deleted {cache_path} to replace.")

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -110,7 +110,7 @@ def cacheable(data_type, cache_args, timeseries=None, cache=True, force_overwrit
                         return cache_map
                     else:
                         print(f"Opening cache {cache_path}")
-                        ds = xr.open_dataset(cache_map, engine='zarr')
+                        ds = xr.open_dataset(cache_map, engine='zarr', chunks='auto')
 
                         if validate_cache_timeseries and timeseries is not None:
                             # Check to see if the dataset extends roughly the full time series set

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -147,6 +147,11 @@ def cacheable(data_type, cache_args, timeseries=None):
                                 # write to a temp cache map
                                 temp_cache_path = 'gs://sheerwater-datalake/caches/temp/' + cache_key
                                 temp_cache_map = fs.get_mapper(temp_cache_path)
+
+                                for var in ds.data_vars:
+                                    if 'chunks' in ds[var].encoding:
+                                        del ds[var].encoding['chunks']
+
                                 ds.chunk(chunks=rechunk).to_zarr(store=temp_cache_map, mode='w')
 
                                 # move to a permanent cache map

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -155,7 +155,7 @@ def cacheable(data_type, cache_args, timeseries=None):
                                 ds.chunk(chunks=rechunk).to_zarr(store=temp_cache_map, mode='w')
 
                                 # move to a permanent cache map
-                                fs.mv(temp_cache_path, cache_path, recusrive=True)
+                                fs.mv(temp_cache_path, cache_path, recursive=True)
 
                                 # Reopen the dataset
                                 ds = xr.open_dataset(cache_map, engine='zarr', chunks={})

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -22,7 +22,7 @@ def get_cache_args(kwargs, cache_kwargs):
     return cache_args
 
 
-def cacheable(data_type, cache_args, timeseries=None, chunking=None):
+def cacheable(data_type, cache_args, timeseries=None):
     # Valid configuration kwargs for the cacheable decorator
     cache_kwargs = {
         "filepath_only": False,
@@ -31,6 +31,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None):
         "validate_cache_timeseries": True,
         "force_overwrite": False,
         "retry_null_cache": False,
+        "rechunk": False,
     }
 
     """Decorator for caching function results.
@@ -53,7 +54,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None):
         def wrapper(*args, **kwargs):
             # Calculate the appropriate cache key
             filepath_only, recompute, cache, validate_cache_timeseries, \
-                force_overwrite, retry_null_cache = get_cache_args(
+                force_overwrite, retry_null_cache, rechunk = get_cache_args(
                     kwargs, cache_kwargs)
 
             params = signature(func).parameters
@@ -132,16 +133,16 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None):
                         # every chunk is only 4B!
                         ds = xr.open_dataset(cache_map, engine='zarr', chunks={})
 
-                        # If chunking is specified aggressively overwrite the cache with the chunks
-                        if chunking:
+                        # If rechunk is passed then check to see if the rechunk array matches chunking. If not then rechunk
+                        if rechunk:
                             # Get the chunks for the dataset
                             ds_chunks = {dim: ds.chunks[dim][0] for dim in ds.chunks}
 
                             # Compare the dict to the rechunk dict
                             print(ds_chunks)
-                            print(chunking)
-                            if ds_chunks != chunking:
-                                print("Chunking was specified and cached chunks do not match specified chunking. Performing rechunking")
+                            print(rechunk)
+                            if ds_chunks != rechunk:
+                                print("Rechunk was passed and cached chunks do not match rechunk request. Performing rechunking")
 
                                 # write to a temp cache map
                                 temp_cache_path = 'gs://sheerwater-datalake/caches/temp/' + cache_key
@@ -151,7 +152,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None):
                                     if 'chunks' in ds[var].encoding:
                                         del ds[var].encoding['chunks']
 
-                                ds.chunk(chunks=chunking).to_zarr(store=temp_cache_map, mode='w')
+                                ds.chunk(chunks=rechunk).to_zarr(store=temp_cache_map, mode='w')
 
                                 # move to a permanent cache map
                                 fs.rm(cache_path, recursive=True)
@@ -160,7 +161,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None):
                                 # Reopen the dataset
                                 ds = xr.open_dataset(cache_map, engine='zarr', chunks={})
                             else:
-                                #print("Requested chunks already match rechunk.")
+                                print("Requested chunks already match rechunk.")
 
 
 

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -126,7 +126,7 @@ def cacheable(data_type, cache_args, timeseries=None):
                         return cache_map
                     else:
                         print(f"Opening cache {cache_path}")
-                        ds = xr.open_dataset(cache_map, engine='zarr', chunks='auto')
+                        ds = xr.open_dataset(cache_map, engine='zarr', chunks=True)
 
                         if validate_cache_timeseries and timeseries is not None:
                             # Check to see if the dataset extends roughly the full time series set
@@ -173,7 +173,8 @@ def cacheable(data_type, cache_args, timeseries=None):
                     elif data_type == 'array':
                         write = False
                         if fs.exists(cache_path) and not force_overwrite:
-                            inp = input(f'A cache already exists at {cache_path}. Are you sure you want to overwrite it? (y/n)')
+                            inp = input(f'A cache already exists at {
+                                        cache_path}. Are you sure you want to overwrite it? (y/n)')
                             if inp == 'y' or inp == 'Y':
                                 write = True
                         else:

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -135,11 +135,8 @@ def cacheable(data_type, cache_args, timeseries=None):
 
                         # If rechunk is passed then check to see if the rechunk array matches chunking. If not then rechunk
                         if rechunk:
-                            # Get the chunks for the zeroth variable
-                            ds_chunks = None
-                            for var in ds.data_vars:
-                                ds_chunks = ds[var].chunks
-                                break
+                            # Get the chunks for the dataset
+                            ds_chunks = {dim: ds1.chunks[dim][0] for dim in ds1.chunks}
 
                             # Compare the dict to the rechunk dict
                             print(ds_chunks)

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -176,7 +176,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
                                     "If auto_rechunk is True, a chunking dict must be supplied.")
 
                             # Compare the dict to the rechunk dict
-                            if !chunking_compare(ds, chunking):
+                            if not chunking_compare(ds, chunking):
                                 print(
                                     "Rechunk was passed and cached chunks do not match rechunk request. Performing rechunking")
 

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -131,7 +131,8 @@ def cacheable(data_type, cache_args, timeseries=None):
                         # We must auto open chunks. This tries to use the underlying zarr chunking if possible.
                         # Setting chunks=True triggers what I think is an xarray/zarr engine bug where
                         # every chunk is only 4B!
-                        ds = xr.open_dataset(cache_map, engine='zarr', chunks={})
+                        with dask.config.set({"array.slicing.split_large_chunks": False}):
+                            ds = xr.open_dataset(cache_map, engine='zarr', chunks={})
 
                         # If rechunk is passed then check to see if the rechunk array matches chunking. If not then rechunk
                         if rechunk:
@@ -143,7 +144,7 @@ def cacheable(data_type, cache_args, timeseries=None):
 
                             # Compare the dict to the rechunk dict
                             if ds_chunks != rechunk:
-                                print("Rechunk was passed and cached chunks do not match rechunk request. Performing recunking")
+                                print("Rechunk was passed and cached chunks do not match rechunk request. Performing rechunking")
                                 with dask.config.set({"array.slicing.split_large_chunks": False}):
                                     ds.chunk(chunks=rechunk).to_zarr(store=cache_map, mode='w')
                             else:

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -167,7 +167,11 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
                                 ds.chunk(chunks=chunking).to_zarr(store=temp_cache_map, mode='w')
 
                                 # move to a permanent cache map
-                                fs.rm(cache_path, recursive=True)
+                                if fs.exists(cache_path)
+                                    print(f"Deleting {cache_path} to replace.")
+                                    fs.rm(cache_path, recursive=True)
+                                    print(f"Confirm deleted {cache_path} to replace.")
+
                                 fs.mv(temp_cache_path, cache_path, recursive=True)
 
                                 # Reopen the dataset

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -126,6 +126,9 @@ def cacheable(data_type, cache_args, timeseries=None):
                         return cache_map
                     else:
                         print(f"Opening cache {cache_path}")
+                        # We must auto open chunks. This tries to use the underlying zarr chunking if possible.
+                        # Setting chunks=True triggers what I think is an xarray/zarr engine bug where
+                        # every chunk is only 4B!
                         ds = xr.open_dataset(cache_map, engine='zarr', chunks={})
 
                         if validate_cache_timeseries and timeseries is not None:

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -126,7 +126,7 @@ def cacheable(data_type, cache_args, timeseries=None):
                         return cache_map
                     else:
                         print(f"Opening cache {cache_path}")
-                        ds = xr.open_dataset(cache_map, engine='zarr', chunks=True)
+                        ds = xr.open_dataset(cache_map, engine='zarr')
 
                         if validate_cache_timeseries and timeseries is not None:
                             # Check to see if the dataset extends roughly the full time series set

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -234,7 +234,6 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, auto_rechun
                                     for var in ds.data_vars:
                                         if 'chunks' in ds[var].encoding:
                                             del ds[var].encoding['chunks']
-.
 
                                     # Get the chunks for the dataset
                                     ds_chunks = {dim: ds.chunks[dim][0] for dim in ds.chunks}

--- a/sheerwater_benchmarking/utils/remote.py
+++ b/sheerwater_benchmarking/utils/remote.py
@@ -22,7 +22,7 @@ def dask_remote(func):
                 # Just setup a coiled cluster
                 logger.info("Attaching to coiled cluster with default configuration")
                 cluster = coiled.Cluster(name='sheerwater-shared',
-                                         n_workers=[3, 10], idle_timeout="45 minutes")
+                                         n_workers=3, idle_timeout="45 minutes")
                 client = cluster.get_client()
         else:
             # Setup a local cluster

--- a/sheerwater_benchmarking/utils/remote.py
+++ b/sheerwater_benchmarking/utils/remote.py
@@ -15,13 +15,13 @@ def dask_remote(func):
                 # setup coiled cluster with remote config
                 logger.info("Attaching to coiled cluster with custom configuration")
                 cluster = coiled.Cluster(**kwargs['remote_config'])
-                _ = cluster.get_client()
+                client = cluster.get_client()
             else:
                 # Just setup a coiled cluster
                 logger.info("Attaching to coiled cluster with default configuration")
                 cluster = coiled.Cluster(name='sheerwater-shared',
                                          n_workers=4, idle_timeout="45 minutes")
-                _ = cluster.get_client()
+                client = cluster.get_client()
         else:
             # Setup a local cluster
             try:

--- a/sheerwater_benchmarking/utils/remote.py
+++ b/sheerwater_benchmarking/utils/remote.py
@@ -22,7 +22,7 @@ def dask_remote(func):
                 # Just setup a coiled cluster
                 logger.info("Attaching to coiled cluster with default configuration")
                 cluster = coiled.Cluster(name='sheerwater-shared',
-                                         n_workers=3, idle_timeout="45 minutes")
+                                         n_workers=4, idle_timeout="45 minutes")
                 client = cluster.get_client()
         else:
             # Setup a local cluster

--- a/sheerwater_benchmarking/utils/remote.py
+++ b/sheerwater_benchmarking/utils/remote.py
@@ -24,8 +24,6 @@ def dask_remote(func):
                 cluster = coiled.Cluster(name='sheerwater-shared',
                                          n_workers=[3, 10], idle_timeout="45 minutes")
                 client = cluster.get_client()
-
-            del kwargs['remote']
         else:
             # Setup a local cluster
             try:
@@ -36,5 +34,8 @@ def dask_remote(func):
                 client = Client(cluster)
 
         # call the function and return the result
+        if 'remote' in kwargs:
+            del kwargs['remote']
+
         return func(*args, **kwargs)
     return wrapper

--- a/sheerwater_benchmarking/utils/remote.py
+++ b/sheerwater_benchmarking/utils/remote.py
@@ -15,15 +15,13 @@ def dask_remote(func):
                 # setup coiled cluster with remote config
                 logger.info("Attaching to coiled cluster with custom configuration")
                 cluster = coiled.Cluster(**kwargs['remote_config'])
-                client = cluster.get_client()
-
-                del kwargs['remote_config']
+                _ = cluster.get_client()
             else:
                 # Just setup a coiled cluster
                 logger.info("Attaching to coiled cluster with default configuration")
                 cluster = coiled.Cluster(name='sheerwater-shared',
                                          n_workers=4, idle_timeout="45 minutes")
-                client = cluster.get_client()
+                _ = cluster.get_client()
         else:
             # Setup a local cluster
             try:
@@ -36,6 +34,9 @@ def dask_remote(func):
         # call the function and return the result
         if 'remote' in kwargs:
             del kwargs['remote']
+
+        if 'remote_config' in kwargs:
+            del kwargs['remote_config']
 
         return func(*args, **kwargs)
     return wrapper

--- a/sheerwater_benchmarking/utils/remote.py
+++ b/sheerwater_benchmarking/utils/remote.py
@@ -10,7 +10,7 @@ def dask_remote(func):
     """Decorator to run a function on a remote dask cluster."""
     def wrapper(*args, **kwargs):
         # See if there are extra function args to run this remotely
-        if 'remote' in kwargs:
+        if 'remote' in kwargs and kwargs['remote']:
             if 'remote_config' in kwargs:
                 # setup coiled cluster with remote config
                 logger.info("Attaching to coiled cluster with custom configuration")


### PR DESCRIPTION
This PR implements the following features:

- Enables a returned object to specify the desired chunking of the zarr cache caching by enabling the object to add a `_chunk_dict property (wrapped object) and check this object on caching.
- Allows a timeseries object to specify the "time column" name as the timeseries argument (many dataframes have "start_date" as the time column name, would be nice for this to be flexible)
- Added an option to force overwrite the cache (false by default) without user prompt, to make data updating more automated if needed
- Fixed the dask remote option to check not only for the presence of the remote kwarg but also its value
- Added auto chunking on load (otherwise, objects are not always loaded as dask arrays)
- Added a flag to cachable decorator to ignore and recompute null caches