### PR TITLE
Cache tabular data: return from cache

### DIFF
--- a/sheerwater_benchmarking/tests/test_caching.py
+++ b/sheerwater_benchmarking/tests/test_caching.py
@@ -116,9 +116,7 @@ def test_tabular_timeseries():
     # new random numbers).
     ds2 = tabular_timeseries(start_time, end_time)
 
-    # Don't use .equals(), because it's OK if times are stored as datetime64[ns] and restored as datetime64[us]
-    assert (ds1.columns == ds2.columns).all()
-    assert (ds1 == ds2.compute()).all().all()
+    assert ds1.compute().equals(ds2.compute())
 
     end_time = '2020-01-07'
     ds3 = tabular_timeseries(start_time, end_time)

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -821,9 +821,9 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, chunk_by_ar
                             f.write(b'')
                             return None
 
+                    write = False  # boolean to determine if we should write to the cache
                     if data_type == 'array':
                         if storage_backend == 'zarr':
-                            write = False
                             if cache_exists(storage_backend, cache_path, verify_path) and not force_overwrite:
                                 inp = input(f'A cache already exists at {
                                             cache_path}. Are you sure you want to overwrite it? (y/n)')
@@ -833,7 +833,6 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, chunk_by_ar
                                 write = True
 
                             if write:
-
                                 print(f"Caching result for {cache_path} as zarr.")
                                 if isinstance(ds, xr.Dataset):
                                     cache_map = fs.get_mapper(cache_path)
@@ -844,19 +843,16 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, chunk_by_ar
                                 else:
                                     raise RuntimeError(
                                         f"Array datatypes must return xarray datasets or None instead of {type(ds)}")
-
                         # Either way if terracotta is specified as a backend try to write the result array to terracotta
                         elif storage_backend == 'terracotta':
                             print(f"Also caching {cache_key} to terracotta.")
                             write_to_terracotta(cache_key, ds)
-
                     elif data_type == 'tabular':
                         if not (isinstance(ds, pd.DataFrame) or isinstance(ds, dd.DataFrame)):
                             raise RuntimeError(f"""Tabular datatypes must return pandas or dask dataframe
                                                or none instead of {type(ds)}""")
 
                         # TODO: combine repeated code
-                        write = False  # boolean to determine if we should write to the cache
                         if storage_backend == 'delta':
                             if fs.exists(cache_path) and not force_overwrite:
                                 inp = input(f'A cache already exists at {

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -837,13 +837,8 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, chunk_by_ar
                                 print(f"Caching result for {cache_path} as zarr.")
                                 if isinstance(ds, xr.Dataset):
                                     cache_map = fs.get_mapper(cache_path)
-
-                                    if chunking:
-                                        # If we aren't doing auto chunking delete the encoding chunks
-                                        chunk_to_zarr(ds, cache_path, verify_path, chunking)
-                                    else:
-                                        chunk_to_zarr(ds, cache_path, verify_path, 'auto')
-
+                                    chunk_config = chunking if chunking else 'auto'
+                                    chunk_to_zarr(ds, cache_path, verify_path, chunk_config)
                                     # Reopen the dataset to truncate the computational path
                                     ds = xr.open_dataset(cache_map, engine='zarr', chunks={}, decode_timedelta=True)
                                 else:
@@ -874,7 +869,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, chunk_by_ar
                             if write:
                                 print(f"Caching result for {cache_path} in delta.")
                                 write_to_delta(cache_path, ds, overwrite=True)
-                                ds = read_from_delta(cache_path) # Reopen dataset to truncate the computational path
+                                ds = read_from_delta(cache_path)  # Reopen dataset to truncate the computational path
                         elif storage_backend == 'parquet':
                             if fs.exists(cache_path) and not force_overwrite:
                                 inp = input(f'A cache already exists at {
@@ -887,7 +882,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, chunk_by_ar
                             if write:
                                 print(f"Caching result for {cache_path} in parquet.")
                                 write_to_parquet(cache_path, ds, overwrite=True)
-                                ds = read_from_parquet(cache_path) # Reopen dataset to truncate the computational path
+                                ds = read_from_parquet(cache_path)  # Reopen dataset to truncate the computational path
 
                         elif storage_backend == 'postgres':
                             if check_exists_postgres(cache_key) and not force_overwrite:
@@ -901,7 +896,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, chunk_by_ar
                             if write:
                                 print(f"Caching result for {cache_key} in postgres.")
                                 write_to_postgres(ds, cache_key, overwrite=True)
-                                ds = read_from_postgres(cache_path) # Reopen dataset to truncate the computational path
+                                ds = read_from_postgres(cache_path)  # Reopen dataset to truncate the computational path
                         else:
                             raise ValueError("Only delta and postgres backends are implemented for tabular data")
                     elif data_type == 'basic':

--- a/sheerwater_benchmarking/utils/caching.py
+++ b/sheerwater_benchmarking/utils/caching.py
@@ -856,7 +856,7 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, chunk_by_ar
                                                or none instead of {type(ds)}""")
 
                         # TODO: combine repeated code
-                        write = False
+                        write = False  # boolean to determine if we should write to the cache
                         if storage_backend == 'delta':
                             if fs.exists(cache_path) and not force_overwrite:
                                 inp = input(f'A cache already exists at {
@@ -901,7 +901,6 @@ def cacheable(data_type, cache_args, timeseries=None, chunking=None, chunk_by_ar
                             raise ValueError("Only delta and postgres backends are implemented for tabular data")
                     elif data_type == 'basic':
                         if backend == 'pickle':
-                            write = False
                             if fs.exists(cache_path) and not force_overwrite:
                                 inp = input(f'A cache already exists at {
                                             cache_path}. Are you sure you want to overwrite it? (y/n)')


### PR DESCRIPTION
After computing and caching tabular data, return data from the cache, not directly from the computation. This makes the returned data more consistent across runs.

Also a little cleanup.