### PR TITLE
Update disk type to ssd from balanced

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -5,3 +5,34 @@ The infrastructure for sheerwater benchmarking
 ./terraform - all of the terraform infrastructure. This includes cloud resources and the deployed of k8s services
 ./terraform-config - the configuration of deployed services (postgres users, grafana dashboards, etc)
 ./dashboards - contains grafana dashboards
+
+
+# Notes:
+
+## Updating a disk resource
+
+After updating a disk resource the pvc and pv will need to be deleted. The following commands can be executed in the gcloud shell to delete the pvc and pv. In this example we are deleting the postgres pvc and pv.
+
+```bash
+# in gcloud shell
+gcloud container clusters get-credentials rhiza-cluster --zone us-central1-a --project rhiza-shared
+
+# list pvc
+# kubectl get pvc -A
+# get the pvc name and namespace you want to delete
+pvc=sheerwater-benchmarking-postgres
+namespace=sheerwater-benchmarking
+
+# delete pvc
+kubectl patch pvc $pvc -p '{"metadata":{"finalizers":null}}' --namespace $namespace 
+kubectl delete persistentvolumeclaim $pvc --namespace $namespace --grace-period=0 --force
+
+# list pv
+# kubectl get pv
+# get the pv name you want to delete
+pv=sheerwater-benchmarking-postgres-pv-sheerwater-benchmarking
+
+# delete pv
+kubectl patch pv $pv -p '{"metadata":{"finalizers":null}}'
+kubectl delete persistentvolume $pv --grace-period=0 --force
+```

--- a/infrastructure/terraform-config/main.tf
+++ b/infrastructure/terraform-config/main.tf
@@ -198,7 +198,7 @@ data "google_secret_manager_secret_version" "sheerwater_oauth_client_secret" {
  secret   = "sheerwater-oauth-client-secret"
 }
 
-# Enable googel oauth
+# Enable google oauth
 resource "grafana_sso_settings" "google_sso_settings" {
   provider_name = "google"
   oauth2_settings {

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -172,7 +172,7 @@ resource "google_compute_resource_policy" "db_snapshot_policy" {
 
 resource "google_compute_disk_resource_policy_attachment" "attachment" {
   name = google_compute_resource_policy.db_snapshot_policy.name
-  disk = google_compute_disk.sheerwater_benchmarking_db.name
+  disk = google_compute_disk.sheerwater_benchmarking_db_ssd.name
   zone = "us-central1-a"
   project = "rhiza-shared"
 }
@@ -289,8 +289,8 @@ locals {
     }
     postgres = {
       pv = {
-        name = "${google_compute_disk.sheerwater_benchmarking_db.name}"
-        size = "${google_compute_disk.sheerwater_benchmarking_db.size}"
+        name = "${google_compute_disk.sheerwater_benchmarking_db_ssd.name}"
+        size = "${google_compute_disk.sheerwater_benchmarking_db_ssd.size}"
       }
       admin_password = "${random_password.db_admin_password.result}"
     }

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -177,21 +177,14 @@ resource "google_compute_disk_resource_policy_attachment" "attachment" {
   project = "rhiza-shared"
 }
 
-# Get the latest snapshot of the old disk
-data "google_compute_snapshot" "latest_db_snapshot" {
-  project = "rhiza-shared"
-  name    = "snapshot-sheerwater-benchmarking-db" # This will be the name format from the snapshot policy
-  most_recent = true
-}
-
-# Create new disk from the snapshot
+# Create new disk from the specific snapshot
 resource "google_compute_disk" "sheerwater_benchmarking_db_ssd" {
   name     = "sheerwater-benchmarking-db-ssd"
   type     = "pd-ssd"
   zone     = "us-central1-a"
   size     = 50
   project  = "rhiza-shared"
-  snapshot = data.google_compute_snapshot.latest_db_snapshot.self_link
+  snapshot = "projects/rhiza-shared/global/snapshots/sheerwater-benchmar-us-central1-a-20250217055130-5p7cuzqi"
 
   # Prevent accidental deletion
   lifecycle {

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -132,7 +132,7 @@ resource "google_secret_manager_secret_version" "postgres_read_password" {
 # Persistent disk
 resource "google_compute_disk" "sheerwater_benchmarking_db" {
   name  = "sheerwater-benchmarking-db"
-  type  = "pd-balanced"
+  type  = "pd-ssd"
   zone  = "us-central1-a"
   size  = 20
   project = "rhiza-shared"


### PR DESCRIPTION
Upgrading the database disk to a ssd from a balanced disk.

The plan on this is a little scary and so far nothing I have found online suggests that doing this will smoothly swap out the storage backend without a disruption in service. I don't think we should apply this until we know how GKE will handle this. Not sure yet if we need to do some snapshot/restore manually before/after changing the disk to restore the data? Or potentially create a new disk first, snapshot/restore the data, switch disks, then delete the old disk to minimize downtime. 

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # google_compute_disk.sheerwater_benchmarking_db must be replaced
-/+ resource "google_compute_disk" "sheerwater_benchmarking_db" {
      + access_mode                 = (known after apply)
      ~ creation_timestamp          = "2024-09-25T11:45:24.877-07:00" -> (known after apply)
      ~ disk_id                     = "8446591530467714219" -> (known after apply)
      ~ effective_labels            = {
          - "goog-gke-cluster-id-base32" = "pqbpgnl3snamdpx7origsswqqgme6vn2acnez6mi2hy6dmqqmzvq" -> null
          - "goog-gke-volume"            = null
          - "goog-k8s-cluster-location"  = "us-central1-a" -> null
          - "goog-k8s-cluster-name"      = "rhiza-cluster" -> null
          - "goog-k8s-node-pool-name"    = "primary-node-pool" -> null
            # (1 unchanged element hidden)
        }
      ~ enable_confidential_compute = false -> (known after apply)
      ~ id                          = "projects/rhiza-shared/zones/us-central1-a/disks/sheerwater-benchmarking-db" -> (known after apply)
      ~ label_fingerprint           = "82UcoasZCq8=" -> (known after apply)
      - labels                      = {} -> null
      ~ last_attach_timestamp       = "2025-02-08T17:35:32.922-08:00" -> (known after apply)
      ~ last_detach_timestamp       = "2025-02-08T17:35:28.254-08:00" -> (known after apply)
      ~ licenses                    = [] -> (known after apply)
        name                        = "sheerwater-benchmarking-db"
      ~ physical_block_size_bytes   = 4096 -> (known after apply)
      ~ provisioned_iops            = 0 -> (known after apply)
      ~ provisioned_throughput      = 0 -> (known after apply)
      ~ self_link                   = "https://www.googleapis.com/compute/v1/projects/rhiza-shared/zones/us-central1-a/disks/sheerwater-benchmarking-db" -> (known after apply)
      + source_disk_id              = (known after apply)
      + source_image_id             = (known after apply)
      + source_snapshot_id          = (known after apply)
      ~ type                        = "pd-balanced" -> "pd-ssd" # forces replacement
      ~ users                       = [
          - "https://www.googleapis.com/compute/v1/projects/rhiza-shared/zones/us-central1-a/instances/gke-rhiza-cluster-primary-node-pool-2ba18d37-nc8k",
        ] -> (known after apply)
        # (9 unchanged attributes hidden)

      ~ guest_os_features (known after apply)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```
