### PR TITLE
Add raster cache configuration for Terracotta deployment

### DIFF
--- a/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-deployment.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-deployment.yaml
@@ -57,11 +57,9 @@ spec:
           - name: TC_ALLOWED_ORIGINS_TILES
             value: '["*"]'
           - name: TC_RASTER_CACHE_SIZE
-            # Size of raster file in-memory cache, in bytes
-            value: 513802240
+            value: {{ .Values.terracotta.raster_cache_size }}
           - name: TC_RASTER_CACHE_COMPRESS_LEVEL
-            # Compression level of raster file in-memory cache, from 0-9
-            value: 9
+            value: {{ .Values.terracotta.raster_cache_compress_level }}
           envFrom:
             - secretRef:
                 name: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta-secrets

--- a/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-deployment.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-deployment.yaml
@@ -56,6 +56,12 @@ spec:
             value: "nearest"
           - name: TC_ALLOWED_ORIGINS_TILES
             value: '["*"]'
+          - name: TC_RASTER_CACHE_SIZE
+            # Size of raster file in-memory cache, in bytes
+            value: 513802240
+          - name: TC_RASTER_CACHE_COMPRESS_LEVEL
+            # Compression level of raster file in-memory cache, from 0-9
+            value: 9
           envFrom:
             - secretRef:
                 name: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta-secrets

--- a/infrastructure/helm/sheerwater-benchmarking/values.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/values.yaml
@@ -54,6 +54,11 @@ terracotta:
 
   driver_path: postgresql://postgres:5432/terracotta
 
+  # Size of raster file in-memory cache, in bytes
+  raster_cache_size: 513802240
+  # Compression level of raster file in-memory cache, from 0-9
+  raster_cache_compress_level: 9
+
   sql_user: read
   sql_password: read_password
 


### PR DESCRIPTION
Configure in-memory raster file cache size and compression level to optimize performance and memory usage

Note: I am not sure exactly what values we want to use here. For now I just put in the current defaults so we can tweak the values from here. 