### PR TITLE
Increase Terracotta CPU resource request

### DIFF
--- a/infrastructure/helm/sheerwater-benchmarking/Chart.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.39
+version: 0.4.40
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/infrastructure/helm/sheerwater-benchmarking/values.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/values.yaml
@@ -66,6 +66,6 @@ terracotta:
 
   resources:
     requests:
-      cpu: 250m
+      cpu: 2000m
       memory: 500Mi
 


### PR DESCRIPTION
- Bump Helm chart version to 0.4.40
- Increase Terracotta CPU resource request from 250m to 2000m

```
Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # helm_release.sheerwater_benchmarking will be updated in-place
  ~ resource "helm_release" "sheerwater_benchmarking" {
        id                         = "sheerwater-benchmarking"
        name                       = "sheerwater-benchmarking"
      ~ version                    = "0.4.39" -> "0.4.40"
        # (26 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

This has been applied