### PR TITLE
Implement Terracotta horizontal scaling with read-only data sync

### DIFF
--- a/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-deployment.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-deployment.yaml
@@ -1,3 +1,13 @@
+# This Deployment manages multiple Terracotta pods with read-only access to raster data.
+# The data synchronization is handled by a separate CronJob that runs every 30 minutes.
+#
+# Key features:
+# 1. All pods are identical read-only replicas
+# 2. Horizontal scaling with consistent read-only access
+#
+# Data consistency is maintained through the separate sync CronJob (single writer)
+# while all Terracotta pods have read-only access to the data.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,7 +16,7 @@ metadata:
     app: {{ include "sheerwater-benchmarking.name" . }}-terracotta
     release: {{ .Release.Name }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.terracotta.replicas }}
   selector:
     matchLabels:
       app: {{ include "sheerwater-benchmarking.name" . }}-terracotta
@@ -60,9 +70,9 @@ spec:
           - name: TC_ALLOWED_ORIGINS_TILES
             value: '["*"]'
           - name: TC_RASTER_CACHE_SIZE
-            value: {{ .Values.terracotta.raster_cache_size }}
+            value: "{{ .Values.terracotta.raster_cache_size }}"
           - name: TC_RASTER_CACHE_COMPRESS_LEVEL
-            value: {{ .Values.terracotta.raster_cache_compress_level }}
+            value: "{{ .Values.terracotta.raster_cache_compress_level }}"
           - name: TC_MULTIPROCESSING_WORKERS
             value: "{{ .Values.terracotta.multiprocessing_workers }}"
           envFrom:
@@ -71,6 +81,7 @@ spec:
           volumeMounts:
             - mountPath: /mnt/sheerwater-datalake
               name: terracotta-rasters
+              readOnly: true  # All Terracotta containers are read-only
       serviceAccountName: sheerwater-sa
       volumes:
         - name: terracotta-rasters

--- a/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-deployment.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-deployment.yaml
@@ -70,9 +70,9 @@ spec:
           - name: TC_ALLOWED_ORIGINS_TILES
             value: '["*"]'
           - name: TC_RASTER_CACHE_SIZE
-            value: "{{ .Values.terracotta.raster_cache_size }}"
+            value: {{ .Values.terracotta.raster_cache_size | int | quote }}
           - name: TC_RASTER_CACHE_COMPRESS_LEVEL
-            value: "{{ .Values.terracotta.raster_cache_compress_level }}"
+            value: {{ .Values.terracotta.raster_cache_compress_level | int | quote }}
           - name: TC_MULTIPROCESSING_WORKERS
             value: "{{ .Values.terracotta.multiprocessing_workers }}"
           envFrom:
@@ -86,4 +86,4 @@ spec:
       volumes:
         - name: terracotta-rasters
           persistentVolumeClaim:
-            claimName: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta 
+            claimName: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta

--- a/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-pv.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-pv.yaml
@@ -38,20 +38,4 @@ spec:
     pdName: {{ .Values.terracotta.pv.name }}  # Same disk as sync PV
     fsType: ext4
     readOnly: true  # Enforce read-only at the disk level
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta
-  labels:
-    app: {{ include "sheerwater-benchmarking.name" . }}-terracotta
-    release: {{ .Release.Name }}
-spec:
-  storageClassName: ""
-  volumeName: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta-pv-{{ .Release.Namespace }}
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: {{ .Values.terracotta.pv.size }}
 

--- a/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-pv.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-pv.yaml
@@ -14,6 +14,7 @@ metadata:
     app: {{ include "sheerwater-benchmarking.name" . }}-terracotta
     release: {{ .Release.Name }}
 spec:
+  persistentVolumeReclaimPolicy: Delete
   accessModes:
   - ReadWriteOnce  # Only sync job can write
   capacity:
@@ -30,6 +31,7 @@ metadata:
     app: {{ include "sheerwater-benchmarking.name" . }}-terracotta
     release: {{ .Release.Name }}
 spec:
+  persistentVolumeReclaimPolicy: Delete
   accessModes:
   - ReadOnlyMany  # All Terracotta containers read-only
   capacity:

--- a/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-pv.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-pv.yaml
@@ -1,3 +1,27 @@
+# This configuration creates two PersistentVolumes that point to the same GCP disk:
+# 1. A read-write PV for the sync job
+# 2. A read-only PV for all Terracotta containers
+#
+# Both PVs use the same underlying GCP disk, but with different access modes:
+# - Sync: ReadWriteOnce to ensure only the sync job can write
+# - Terracotta: ReadOnlyMany to allow all Terracotta containers to read
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta-sync-pv-{{ .Release.Namespace }}
+  labels:
+    app: {{ include "sheerwater-benchmarking.name" . }}-terracotta
+    release: {{ .Release.Name }}
+spec:
+  accessModes:
+  - ReadWriteOnce  # Only sync job can write
+  capacity:
+    storage: {{ .Values.terracotta.pv.size }}
+  gcePersistentDisk:
+    pdName: {{ .Values.terracotta.pv.name }}
+    fsType: ext4
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -7,12 +31,13 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   accessModes:
-  - ReadWriteMany
+  - ReadOnlyMany  # All Terracotta containers read-only
   capacity:
     storage: {{ .Values.terracotta.pv.size }}
   gcePersistentDisk:
-    pdName: {{ .Values.terracotta.pv.name }}
+    pdName: {{ .Values.terracotta.pv.name }}  # Same disk as sync PV
     fsType: ext4
+    readOnly: true  # Enforce read-only at the disk level
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-pvc.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-pvc.yaml
@@ -1,0 +1,37 @@
+# This file defines two PVCs:
+# 1. A read-write PVC for the sync job
+# 2. A read-only PVC for all Terracotta containers
+#
+# Both PVCs point to their respective PVs which share the same underlying GCP disk
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta-sync
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "sheerwater-benchmarking.name" . }}-terracotta
+    release: {{ .Release.Name }}
+spec:
+  storageClassName: ""
+  volumeName: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta-sync-pv-{{ .Release.Namespace }}
+  accessModes: [ "ReadWriteOnce" ]
+  resources:
+    requests:
+      storage: {{ .Values.terracotta.pv.size }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "sheerwater-benchmarking.name" . }}-terracotta
+    release: {{ .Release.Name }}
+spec:
+  storageClassName: ""
+  volumeName: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta-pv-{{ .Release.Namespace }}
+  accessModes: [ "ReadOnlyMany" ]
+  resources:
+    requests:
+      storage: {{ .Values.terracotta.pv.size }} 

--- a/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-sync-cronjob.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/templates/terracotta-sync-cronjob.yaml
@@ -1,0 +1,61 @@
+# This CronJob handles synchronization of raster data from GCS to the shared volume.
+# It runs every 30 minutes and has exclusive write access to the volume.
+#
+# The job uses the read-write PVC to update the data, while all Terracotta pods
+# maintain read-only access through their separate PVC.
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta-sync
+  labels:
+    app: {{ include "sheerwater-benchmarking.name" . }}-terracotta
+    release: {{ .Release.Name }}
+spec:
+  schedule: "*/30 * * * *"  # Every 30 minutes
+  concurrencyPolicy: Forbid  # Don't start new job if previous is still running
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: {{ include "sheerwater-benchmarking.name" . }}-terracotta
+            release: {{ .Release.Name }}
+        spec:
+          containers:
+            - name: sync
+              image: gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
+              command: ["/bin/bash"]
+              args:
+                - -c
+                - |
+                  echo "Starting raster sync at $(date)"
+                  gcloud storage rsync -r -u gs://sheerwater-datalake/rasters /mnt/sheerwater-datalake
+                  sync_status=$?
+                  
+                  if [ $sync_status -eq 0 ]; then
+                    echo "Sync completed successfully at $(date)"
+                    exit 0
+                  else
+                    echo "Sync failed with status $sync_status at $(date)"
+                    exit 1
+                  fi
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+              volumeMounts:
+                - mountPath: /mnt/sheerwater-datalake
+                  name: rasters
+                  readOnly: false  # Sync job needs write access
+          restartPolicy: OnFailure
+          serviceAccountName: sheerwater-sa
+          volumes:
+            - name: rasters
+              persistentVolumeClaim:
+                claimName: {{ include "sheerwater-benchmarking.fullname" . }}-terracotta-sync 

--- a/infrastructure/helm/sheerwater-benchmarking/values.yaml
+++ b/infrastructure/helm/sheerwater-benchmarking/values.yaml
@@ -50,6 +50,9 @@ terracotta:
     repository: ghcr.io/rhiza-research/terracotta
     tag: "v0.0.14"
 
+  # Number of replicas for horizontal scaling
+  replicas: 3
+
   tailscale: true
 
   driver_path: postgresql://postgres:5432/terracotta
@@ -59,7 +62,7 @@ terracotta:
   # Compression level of raster file in-memory cache, from 0-9
   raster_cache_compress_level: 9
 
-  multiprocessing_workers: 24
+  multiprocessing_workers: 6
 
   sql_user: read
   sql_password: read_password
@@ -74,8 +77,7 @@ terracotta:
   resources:
     requests:
       cpu: 2000m
-      memory: 1500Mi
+      memory: 500Mi
     limits:
       cpu: 2000m
-      memory: 2000Mi
-
+      memory: 1000Mi


### PR DESCRIPTION

- Add support for multiple Terracotta replicas with configurable count
- Create separate read-write and read-only PersistentVolumes and PersistentVolumeClaims
- Implement a CronJob to synchronize raster data every 30 minutes
- Reduce Terracotta resource allocation:
  * Decrease multiprocessing workers from 24 to 6
  * Reduce memory request from 1500Mi to 500Mi
  * Lower memory limit from 2000Mi to 1000Mi
- Enforce read-only access for Terracotta containers