### PR TITLE
feat: add sheerwater CLI with data, forecast, ops, and eval verbs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ dependencies = [
     "xee",
 ]
 
+[project.scripts]
+sheerwater = "sheerwater.cli:main"
+
 [dependency-groups]
 dev = [
     "pooch",

--- a/sheerwater/cli/__init__.py
+++ b/sheerwater/cli/__init__.py
@@ -1,0 +1,41 @@
+"""Top-level Sheerwater CLI.
+
+Exposes sheerwater's data, forecast, ops, eval, and list verbs as a kubectl-style
+click group. Skills in `sheerwater/skills/` document the per-verb invocations the
+agent should use.
+
+Cache management is provided by the `nuthatch` CLI directly; sheerwater does not
+re-export it here.
+"""
+import click
+
+from . import data, eval, forecast, list_, ops
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def cli():
+    """Sheerwater: weather data, forecasts, ops, and benchmarking.
+
+    Authentication: public datasets work anonymously against sheerwater's
+    public GCS bucket. Private datasets require GCS credentials via
+    GOOGLE_APPLICATION_CREDENTIALS or `gcloud auth application-default login`.
+
+    Cache management uses the `nuthatch` CLI directly (sheerwater's caches are
+    backed by nuthatch).
+    """
+
+
+cli.add_command(data.data, name="data")
+cli.add_command(forecast.forecast, name="forecast")
+cli.add_command(ops.ops, name="ops")
+cli.add_command(eval.eval_, name="eval")
+cli.add_command(list_.list_, name="list")
+
+
+def main():
+    """Entry point for the `sheerwater` console script."""
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/sheerwater/cli/_envelope.py
+++ b/sheerwater/cli/_envelope.py
@@ -1,0 +1,105 @@
+"""Shared helpers for writing Rhiza Envelope-compliant Zarr stores.
+
+The envelope is defined in forecasting-skills/ENVELOPE.md. Briefly:
+- spatial dims `latitude`/`longitude` (or station_id for station envelopes), CF attrs
+- temporal dims `time` (observations) or `step` + scalar `time` (forecasts)
+- root attrs prefixed `rhiza_*` for traceability
+- per-variable encoding cleared, written with `consolidated=True`
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+import xarray as xr
+
+
+_LAT_NAMES = ("latitude", "lat", "y")
+_LON_NAMES = ("longitude", "lon", "x")
+
+
+def stamp_cf_coords(ds: xr.Dataset) -> xr.Dataset:
+    """Stamp CF standard_name/units/axis on spatial and time coords."""
+    for name in _LAT_NAMES:
+        if name in ds.coords:
+            ds[name].attrs.setdefault("standard_name", "latitude")
+            ds[name].attrs.setdefault("units", "degrees_north")
+            ds[name].attrs.setdefault("axis", "Y")
+            break
+    for name in _LON_NAMES:
+        if name in ds.coords:
+            ds[name].attrs.setdefault("standard_name", "longitude")
+            ds[name].attrs.setdefault("units", "degrees_east")
+            ds[name].attrs.setdefault("axis", "X")
+            break
+    if "time" in ds.coords:
+        ds["time"].attrs.setdefault("standard_name", "time")
+        ds["time"].attrs.setdefault("axis", "T")
+    return ds
+
+
+def stamp_root_attrs(ds: xr.Dataset, **rhiza_attrs: Any) -> xr.Dataset:
+    """Stamp `rhiza_*` attrs on the dataset root.
+
+    Pass attribute names without the `rhiza_` prefix; e.g. `source="chirps"` becomes
+    `rhiza_source="chirps"`. None values are dropped.
+    """
+    for key, value in rhiza_attrs.items():
+        if value is None:
+            continue
+        ds.attrs[f"rhiza_{key}"] = str(value)
+    return ds
+
+
+def clear_encoding(ds: xr.Dataset) -> xr.Dataset:
+    """Clear per-variable encoding (codecs, chunks, dtype, fill_value).
+
+    Required by the envelope: encoding is not part of the contract and codec
+    objects are not guaranteed to round-trip across skill boundaries.
+    """
+    for v in ds.variables:
+        ds[v].encoding = {}
+    return ds
+
+
+def write_envelope(
+    ds: xr.Dataset,
+    output: str | Path,
+    *,
+    source: str | None = None,
+    region: str | None = None,
+    date: str | None = None,
+    aggregation: str | None = None,
+    downscale_factor: int | None = None,
+    overwrite: bool = True,
+) -> Path:
+    """Write a dataset as a Rhiza Envelope-compliant Zarr store.
+
+    Stamps CF coord attrs, the requested `rhiza_*` root attrs, clears per-variable
+    encoding, and writes with `consolidated=True`.
+    """
+    out = Path(output)
+    if out.exists():
+        if not overwrite:
+            raise FileExistsError(out)
+        shutil.rmtree(out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    ds = stamp_cf_coords(ds)
+    ds = stamp_root_attrs(
+        ds,
+        source=source,
+        region=region,
+        date=date,
+        aggregation=aggregation,
+        downscale_factor=downscale_factor,
+    )
+    ds = clear_encoding(ds)
+    ds.to_zarr(out, mode="w", consolidated=True)
+    return out
+
+
+def open_envelope(input_path: str | Path) -> xr.Dataset:
+    """Open a Zarr envelope for reading."""
+    return xr.open_zarr(str(input_path), consolidated=True, decode_timedelta=True)

--- a/sheerwater/cli/_errors.py
+++ b/sheerwater/cli/_errors.py
@@ -1,0 +1,81 @@
+"""Translate sheerwater/nuthatch/GCS errors into clean CLI messages.
+
+Sheerwater fetches go through nuthatch → fsspec/gcsfs → GCS. When auth is
+missing or insufficient the underlying exception is opaque (DefaultCredentialsError,
+Forbidden, RefreshError, OSError chained off a 401/403). The CLI wraps each
+verb invocation in `cli_run` so the user gets a one-line "you need
+GOOGLE_APPLICATION_CREDENTIALS for this dataset" instead of a stack trace.
+"""
+from __future__ import annotations
+
+import functools
+import sys
+from collections.abc import Callable
+from typing import Any
+
+import click
+
+
+_AUTH_HINT = (
+    "Authentication required for this dataset.\n"
+    "Set GOOGLE_APPLICATION_CREDENTIALS to a service-account JSON path, or run "
+    "`gcloud auth application-default login`. Public-bucket datasets work without auth."
+)
+
+
+def _is_gcs_auth_error(exc: BaseException) -> bool:
+    """Detect GCS auth/permission failures across the layers we go through."""
+    # Walk the chain; gcsfs/google-cloud-storage often wrap underlying errors.
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        cls_name = type(current).__name__
+        module = type(current).__module__
+        if module.startswith("google.auth.exceptions") and cls_name in {
+            "DefaultCredentialsError",
+            "RefreshError",
+            "GoogleAuthError",
+        }:
+            return True
+        if module.startswith("google.api_core.exceptions") and cls_name in {
+            "Forbidden",
+            "Unauthorized",
+            "PermissionDenied",
+        }:
+            return True
+        if module.startswith("google.cloud.exceptions") and cls_name in {
+            "Forbidden",
+            "Unauthorized",
+        }:
+            return True
+        # gcsfs / aiohttp tend to surface 401/403 as messages on plain Exceptions.
+        msg = str(current)
+        if "401" in msg or "403" in msg or "Anonymous caller" in msg or "credentials" in msg.lower():
+            if any(token in msg for token in ("gs://", "googleapis", "storage.googleapis", "oauth2")):
+                return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def cli_run(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator: translate auth errors into a clean ClickException.
+
+    Other exceptions are re-raised unchanged so click prints its normal traceback
+    in --debug mode and a short summary otherwise.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return fn(*args, **kwargs)
+        except click.ClickException:
+            raise
+        except Exception as exc:  # noqa: BLE001 — translation layer
+            if _is_gcs_auth_error(exc):
+                click.echo(f"sheerwater: {_AUTH_HINT}", err=True)
+                click.echo(f"  underlying error: {type(exc).__name__}: {exc}", err=True)
+                sys.exit(2)
+            raise
+
+    return wrapper

--- a/sheerwater/cli/data.py
+++ b/sheerwater/cli/data.py
@@ -1,0 +1,105 @@
+"""`sheerwater data` — fetch and list data sources from the registry.
+
+Data sources are functions decorated with `@sheerwater_data` (see
+`sheerwater.interfaces.datasets`). The CLI is registry-driven so adding a new
+data source automatically makes it available here.
+"""
+from __future__ import annotations
+
+import sys
+
+import click
+
+from ._envelope import write_envelope
+from ._errors import cli_run
+
+
+@click.group()
+def data():
+    """Fetch and discover data sources (observations, reanalysis, station data)."""
+
+
+@data.command("list")
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON array instead of newline-separated names.")
+def list_data_cmd(as_json: bool) -> None:
+    """List all registered data source names."""
+    from sheerwater.interfaces import list_data
+
+    names = sorted(list_data())
+    if as_json:
+        import json as _json
+
+        click.echo(_json.dumps(names))
+    else:
+        for n in names:
+            click.echo(n)
+
+
+@data.command("fetch")
+@click.argument("name")
+@click.option("--start", "start_time", help="Start date YYYY-MM-DD (function default if omitted).")
+@click.option("--end", "end_time", help="End date YYYY-MM-DD (function default if omitted).")
+@click.option("--variable", "-v", help="Variable name (e.g. precip, tmp2m).")
+@click.option("--agg-days", type=int, help="Aggregation period in days.")
+@click.option("--grid", help="Output grid (e.g. global0_25, global1_5).")
+@click.option("--mask", help="Mask name (e.g. lsm) or 'none' to disable.")
+@click.option("--region", help="Region name (e.g. global, kenya, ethiopia).")
+@click.option("--recompute", is_flag=True, help="Force recompute, bypass cache.")
+@click.option("--cache-mode", help="Nuthatch cache mode (e.g. local_overwrite).")
+@click.option("--output", "-o", required=True, help="Output Zarr path.")
+@cli_run
+def fetch_data(
+    name: str,
+    start_time: str | None,
+    end_time: str | None,
+    variable: str | None,
+    agg_days: int | None,
+    grid: str | None,
+    mask: str | None,
+    region: str | None,
+    recompute: bool,
+    cache_mode: str | None,
+    output: str,
+) -> None:
+    """Fetch a registered data source and write an envelope-compliant Zarr.
+
+    NAME is one of the registered data source names (see `sheerwater data list`).
+    """
+    from sheerwater.interfaces import get_data
+
+    try:
+        fn = get_data(name)
+    except (KeyError, ValueError) as exc:
+        raise click.ClickException(str(exc))
+
+    kwargs: dict = {}
+    if start_time is not None:
+        kwargs["start_time"] = start_time
+    if end_time is not None:
+        kwargs["end_time"] = end_time
+    if variable is not None:
+        kwargs["variable"] = variable
+    if agg_days is not None:
+        kwargs["agg_days"] = agg_days
+    if grid is not None:
+        kwargs["grid"] = grid
+    if mask is not None:
+        kwargs["mask"] = None if mask.lower() == "none" else mask
+    if region is not None:
+        kwargs["region"] = region
+    if recompute:
+        kwargs["recompute"] = True
+    if cache_mode is not None:
+        kwargs["cache_mode"] = cache_mode
+
+    print(f"Fetching {name} -> {output}", file=sys.stderr)
+    ds = fn(**kwargs)
+
+    out = write_envelope(
+        ds,
+        output,
+        source=name,
+        region=region,
+        date=end_time,
+    )
+    print(f"Wrote: {out}", file=sys.stderr)

--- a/sheerwater/cli/eval.py
+++ b/sheerwater/cli/eval.py
@@ -1,0 +1,221 @@
+"""`sheerwater eval` — compute forecast verification metrics.
+
+Backed by `sheerwater.metrics.metric`. Default output is JSON for scalar / table
+results; pass `--zarr-output` (and use `--spatial`) to emit gridded residuals as
+an envelope-compliant Zarr.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+
+from ._envelope import write_envelope
+from ._errors import cli_run
+
+
+def _ds_to_json_value(ds) -> dict:
+    """Reduce an xarray Dataset to a JSON-serialisable dict.
+
+    Scalars become floats; gridded results are summarised as the per-variable
+    mean (with a note) rather than dumping arrays into JSON.
+    """
+    out: dict = {}
+    for var in ds.data_vars:
+        arr = ds[var]
+        if arr.size == 1:
+            out[var] = float(arr.values)
+        elif arr.ndim == 0 or all(d == 1 for d in arr.shape):
+            out[var] = float(arr.values.flatten()[0])
+        else:
+            # Reduce to a per-coord mapping if the result is small (e.g. per region).
+            try:
+                out[var] = arr.to_pandas().to_dict()
+            except Exception:
+                out[var] = {
+                    "_note": "result has structure; use --zarr-output for full data",
+                    "mean": float(arr.mean().values),
+                    "shape": list(arr.shape),
+                    "dims": list(arr.dims),
+                }
+    return out
+
+
+@click.group("eval")
+def eval_():
+    """Forecast verification metrics."""
+
+
+@eval_.command("metric")
+@click.option("--forecast", required=True, help="Forecast model name (see `sheerwater forecast list`).")
+@click.option("--truth", required=True, help="Truth dataset name (see `sheerwater data list`).")
+@click.option("--metric", "metric_name", required=True, help="Metric name (see `sheerwater list metrics`).")
+@click.option("--start", "start_time", required=True, help="Start date YYYY-MM-DD.")
+@click.option("--end", "end_time", required=True, help="End date YYYY-MM-DD.")
+@click.option("--variable", "-v", default="precip", show_default=True)
+@click.option("--agg-days", type=int, default=1, show_default=True)
+@click.option("--grid", default="global1_5", show_default=True)
+@click.option("--mask", default="lsm", show_default=True, help="Use 'none' to disable masking.")
+@click.option("--region", default="global", show_default=True)
+@click.option("--time-grouping", help="Time grouping (e.g. month, year, month_of_year).")
+@click.option("--space-grouping", help="Space grouping (e.g. country, region).")
+@click.option("--spatial", is_flag=True, help="Return gridded result instead of grouped scalar.")
+@click.option("--output", "-o", help="JSON output path (default: stdout).")
+@click.option("--zarr-output", help="Zarr output path for gridded result (implies --spatial).")
+@cli_run
+def metric_cmd(
+    forecast: str,
+    truth: str,
+    metric_name: str,
+    start_time: str,
+    end_time: str,
+    variable: str,
+    agg_days: int,
+    grid: str,
+    mask: str,
+    region: str,
+    time_grouping: str | None,
+    space_grouping: str | None,
+    spatial: bool,
+    output: str | None,
+    zarr_output: str | None,
+) -> None:
+    """Compute a single verification metric for a forecast vs a truth source."""
+    from sheerwater.metrics import metric
+
+    if zarr_output:
+        spatial = True
+
+    mask_arg = None if mask.lower() == "none" else mask
+
+    print(
+        f"Computing {metric_name}({forecast}, {truth}) {start_time}..{end_time} "
+        f"region={region} grid={grid}",
+        file=sys.stderr,
+    )
+    ds = metric(
+        start_time=start_time,
+        end_time=end_time,
+        variable=variable,
+        forecast=forecast,
+        truth=truth,
+        metric_name=metric_name,
+        agg_days=agg_days,
+        time_grouping=time_grouping,
+        space_grouping=space_grouping,
+        spatial=spatial,
+        grid=grid,
+        mask=mask_arg,
+        region=region,
+    )
+
+    if zarr_output:
+        out = write_envelope(
+            ds,
+            zarr_output,
+            source=f"eval:{metric_name}({forecast},{truth})",
+            region=region,
+        )
+        print(f"Wrote gridded result: {out}", file=sys.stderr)
+    else:
+        result = {
+            "forecast": forecast,
+            "truth": truth,
+            "metric": metric_name,
+            "variable": variable,
+            "agg_days": agg_days,
+            "grid": grid,
+            "region": region,
+            "start_time": start_time,
+            "end_time": end_time,
+            "values": _ds_to_json_value(ds),
+        }
+        text = json.dumps(result, indent=2, default=str)
+        if output:
+            with open(output, "w") as f:
+                f.write(text)
+                f.write("\n")
+            print(f"Wrote: {output}", file=sys.stderr)
+        else:
+            click.echo(text)
+
+
+@eval_.command("compare")
+@click.option(
+    "--forecasts",
+    required=True,
+    help="Comma-separated forecast names.",
+)
+@click.option("--truth", required=True, help="Truth dataset name.")
+@click.option(
+    "--metrics",
+    required=True,
+    help="Comma-separated metric names.",
+)
+@click.option("--start", "start_time", required=True, help="Start date YYYY-MM-DD.")
+@click.option("--end", "end_time", required=True, help="End date YYYY-MM-DD.")
+@click.option("--variable", "-v", default="precip", show_default=True)
+@click.option("--agg-days", type=int, default=1, show_default=True)
+@click.option("--grid", default="global1_5", show_default=True)
+@click.option("--mask", default="lsm", show_default=True, help="Use 'none' to disable masking.")
+@click.option("--region", default="global", show_default=True)
+@click.option("--output", "-o", help="JSON output path (default: stdout).")
+@cli_run
+def compare_cmd(
+    forecasts: str,
+    truth: str,
+    metrics: str,
+    start_time: str,
+    end_time: str,
+    variable: str,
+    agg_days: int,
+    grid: str,
+    mask: str,
+    region: str,
+    output: str | None,
+) -> None:
+    """Compute a matrix of metrics for multiple forecasts against one truth source."""
+    from sheerwater.metrics import metric
+
+    forecast_names = [f.strip() for f in forecasts.split(",") if f.strip()]
+    metric_names = [m.strip() for m in metrics.split(",") if m.strip()]
+    mask_arg = None if mask.lower() == "none" else mask
+
+    matrix: dict[str, dict] = {}
+    for fcst in forecast_names:
+        matrix[fcst] = {}
+        for met in metric_names:
+            print(f"  {met}({fcst}, {truth})", file=sys.stderr)
+            ds = metric(
+                start_time=start_time,
+                end_time=end_time,
+                variable=variable,
+                forecast=fcst,
+                truth=truth,
+                metric_name=met,
+                agg_days=agg_days,
+                grid=grid,
+                mask=mask_arg,
+                region=region,
+            )
+            matrix[fcst][met] = _ds_to_json_value(ds)
+
+    result = {
+        "truth": truth,
+        "variable": variable,
+        "agg_days": agg_days,
+        "grid": grid,
+        "region": region,
+        "start_time": start_time,
+        "end_time": end_time,
+        "matrix": matrix,
+    }
+    text = json.dumps(result, indent=2, default=str)
+    if output:
+        with open(output, "w") as f:
+            f.write(text)
+            f.write("\n")
+        print(f"Wrote: {output}", file=sys.stderr)
+    else:
+        click.echo(text)

--- a/sheerwater/cli/forecast.py
+++ b/sheerwater/cli/forecast.py
@@ -1,0 +1,104 @@
+"""`sheerwater forecast` — fetch and list forecast models from the registry."""
+from __future__ import annotations
+
+import sys
+
+import click
+
+from ._envelope import write_envelope
+from ._errors import cli_run
+
+
+@click.group()
+def forecast():
+    """Fetch and discover forecast models."""
+
+
+@forecast.command("list")
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON array instead of newline-separated names.")
+def list_forecasts_cmd(as_json: bool) -> None:
+    """List all registered forecast model names."""
+    from sheerwater.interfaces import list_forecasts
+
+    names = sorted(list_forecasts())
+    if as_json:
+        import json as _json
+
+        click.echo(_json.dumps(names))
+    else:
+        for n in names:
+            click.echo(n)
+
+
+@forecast.command("fetch")
+@click.argument("name")
+@click.option("--start", "start_time", help="Start date YYYY-MM-DD (function default if omitted).")
+@click.option("--end", "end_time", help="End date YYYY-MM-DD (function default if omitted).")
+@click.option("--variable", "-v", help="Variable name (e.g. precip, tmp2m).")
+@click.option("--agg-days", type=int, help="Aggregation period in days.")
+@click.option("--grid", help="Output grid (e.g. global0_25, global1_5).")
+@click.option("--mask", help="Mask name (e.g. lsm) or 'none' to disable.")
+@click.option("--region", help="Region name (e.g. global, kenya, ethiopia).")
+@click.option("--prob-type", help="Probability type (e.g. deterministic, probabilistic, ensemble).")
+@click.option("--recompute", is_flag=True, help="Force recompute, bypass cache.")
+@click.option("--cache-mode", help="Nuthatch cache mode (e.g. local_overwrite).")
+@click.option("--output", "-o", required=True, help="Output Zarr path.")
+@cli_run
+def fetch_forecast(
+    name: str,
+    start_time: str | None,
+    end_time: str | None,
+    variable: str | None,
+    agg_days: int | None,
+    grid: str | None,
+    mask: str | None,
+    region: str | None,
+    prob_type: str | None,
+    recompute: bool,
+    cache_mode: str | None,
+    output: str,
+) -> None:
+    """Fetch a registered forecast and write an envelope-compliant Zarr.
+
+    NAME is one of the registered forecast names (see `sheerwater forecast list`).
+    """
+    from sheerwater.interfaces import get_forecast
+
+    try:
+        fn = get_forecast(name)
+    except (KeyError, ValueError) as exc:
+        raise click.ClickException(str(exc))
+
+    kwargs: dict = {}
+    if start_time is not None:
+        kwargs["start_time"] = start_time
+    if end_time is not None:
+        kwargs["end_time"] = end_time
+    if variable is not None:
+        kwargs["variable"] = variable
+    if agg_days is not None:
+        kwargs["agg_days"] = agg_days
+    if grid is not None:
+        kwargs["grid"] = grid
+    if mask is not None:
+        kwargs["mask"] = None if mask.lower() == "none" else mask
+    if region is not None:
+        kwargs["region"] = region
+    if prob_type is not None:
+        kwargs["prob_type"] = prob_type
+    if recompute:
+        kwargs["recompute"] = True
+    if cache_mode is not None:
+        kwargs["cache_mode"] = cache_mode
+
+    print(f"Fetching forecast {name} -> {output}", file=sys.stderr)
+    ds = fn(**kwargs)
+
+    out = write_envelope(
+        ds,
+        output,
+        source=name,
+        region=region,
+        date=end_time,
+    )
+    print(f"Wrote: {out}", file=sys.stderr)

--- a/sheerwater/cli/list_.py
+++ b/sheerwater/cli/list_.py
@@ -1,0 +1,48 @@
+"""`sheerwater list` — discovery commands for datasets, forecasts, and metrics."""
+from __future__ import annotations
+
+import click
+
+
+def _emit(names, as_json: bool) -> None:
+    if as_json:
+        import json
+
+        click.echo(json.dumps(sorted(names)))
+    else:
+        for n in sorted(names):
+            click.echo(n)
+
+
+@click.group("list")
+def list_():
+    """Discovery: list registered datasets, forecasts, and metrics."""
+
+
+@list_.command("datasets")
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON array.")
+def list_datasets(as_json: bool) -> None:
+    """List all registered data source names."""
+    from sheerwater.interfaces import list_data
+
+    _emit(list_data(), as_json)
+
+
+@list_.command("forecasts")
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON array.")
+def list_forecasts_cmd(as_json: bool) -> None:
+    """List all registered forecast model names."""
+    from sheerwater.interfaces import list_forecasts
+
+    _emit(list_forecasts(), as_json)
+
+
+@list_.command("metrics")
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON array.")
+def list_metrics(as_json: bool) -> None:
+    """List all registered verification metric names."""
+    # Import metrics_library to populate the metric registry.
+    import sheerwater.metrics_library  # noqa: F401
+    from sheerwater.metrics_library import SHEERWATER_METRIC_REGISTRY
+
+    _emit(SHEERWATER_METRIC_REGISTRY.keys(), as_json)

--- a/sheerwater/cli/ops.py
+++ b/sheerwater/cli/ops.py
@@ -1,0 +1,124 @@
+"""`sheerwater ops` — spatial and temporal transforms on envelope Zarr stores.
+
+Each op reads a Zarr in, transforms in memory, writes a Zarr out. Stamps
+the relevant `rhiza_*` attribute (region / aggregation / downscale_factor)
+so downstream skills can see what was applied.
+"""
+from __future__ import annotations
+
+import sys
+
+import click
+
+from ._envelope import open_envelope, write_envelope
+
+
+@click.group()
+def ops():
+    """Spatial and temporal operations on envelope Zarr stores."""
+
+
+@ops.command("clip")
+@click.option("--input", "-i", "input_path", required=True, help="Input Zarr path.")
+@click.option("--region", required=True, help="Region name (e.g. kenya, ethiopia, global).")
+@click.option("--grid", required=True, help="Grid the region is defined against (e.g. global0_25, global1_5).")
+@click.option("--output", "-o", required=True, help="Output Zarr path.")
+def clip_cmd(input_path: str, region: str, grid: str, output: str) -> None:
+    """Clip a dataset to a named region.
+
+    Backed by `sheerwater.spatial_subdivisions.clip_region`.
+    """
+    from sheerwater.spatial_subdivisions import clip_region
+
+    print(f"Clipping {input_path} to region={region} grid={grid}", file=sys.stderr)
+    ds = open_envelope(input_path)
+    ds = clip_region(ds, region=region, grid=grid)
+
+    out = write_envelope(ds, output, region=region)
+    print(f"Wrote: {out}", file=sys.stderr)
+
+
+@ops.command("regrid")
+@click.option("--input", "-i", "input_path", required=True, help="Input Zarr path.")
+@click.option("--grid", "output_grid", required=True, help="Output grid (e.g. global0_25, global1_5).")
+@click.option(
+    "--method",
+    type=click.Choice(["linear", "nearest", "cubic", "conservative", "most_common"]),
+    default="conservative",
+    show_default=True,
+)
+@click.option(
+    "--base",
+    type=click.Choice(["base180", "base360"]),
+    default="base180",
+    show_default=True,
+    help="Longitude base of the output grid.",
+)
+@click.option("--region", default="global", show_default=True, help="Region to clip the output grid to.")
+@click.option("--output", "-o", required=True, help="Output Zarr path.")
+def regrid_cmd(
+    input_path: str, output_grid: str, method: str, base: str, region: str, output: str
+) -> None:
+    """Regrid a dataset to a new grid resolution.
+
+    Backed by `sheerwater.utils.data_utils.regrid`.
+    """
+    from sheerwater.utils.data_utils import regrid
+
+    print(f"Regridding {input_path} -> grid={output_grid} method={method}", file=sys.stderr)
+    ds = open_envelope(input_path)
+    ds = regrid(ds, output_grid=output_grid, method=method, base=base, region=region)
+
+    out = write_envelope(ds, output)
+    print(f"Wrote: {out}", file=sys.stderr)
+
+
+@ops.command("aggregate")
+@click.option("--input", "-i", "input_path", required=True, help="Input Zarr path.")
+@click.option("--agg", required=True, type=int, help="Rolling aggregation window (in units of agg-col).")
+@click.option(
+    "--agg-col",
+    default="time",
+    show_default=True,
+    help="Coordinate to roll over (typically `time` or `step`).",
+)
+@click.option(
+    "--agg-fn",
+    type=click.Choice(["mean", "sum"]),
+    default="mean",
+    show_default=True,
+)
+@click.option(
+    "--agg-thresh",
+    type=int,
+    help="Minimum number of valid points required in the window (default: agg).",
+)
+@click.option("--output", "-o", required=True, help="Output Zarr path.")
+def aggregate_cmd(
+    input_path: str,
+    agg: int,
+    agg_col: str,
+    agg_fn: str,
+    agg_thresh: int | None,
+    output: str,
+) -> None:
+    """Rolling temporal aggregation (mean or sum) over an N-step window.
+
+    Backed by `sheerwater.utils.data_utils.roll_and_agg`. Output windows are
+    left-aligned.
+    """
+    from sheerwater.utils.data_utils import roll_and_agg
+
+    print(
+        f"Aggregating {input_path} agg={agg} {agg_col} fn={agg_fn}",
+        file=sys.stderr,
+    )
+    ds = open_envelope(input_path)
+    ds = roll_and_agg(ds, agg=agg, agg_col=agg_col, agg_fn=agg_fn, agg_thresh=agg_thresh)
+
+    out = write_envelope(
+        ds,
+        output,
+        aggregation=f"{agg}-{agg_col}-{agg_fn}",
+    )
+    print(f"Wrote: {out}", file=sys.stderr)

--- a/sheerwater/data/chirps.py
+++ b/sheerwater/data/chirps.py
@@ -12,6 +12,17 @@ from nuthatch.processors import timeseries
 from sheerwater.utils import dask_remote, regrid, roll_and_agg
 from sheerwater.interfaces import data as sheerwater_data, spatial
 
+# TODO: Register chirps_raw_live as a sheerwater_data accessor (or add a
+# matching `chirps_live` wrapper that does) so the CLI / skills can expose
+# the current-calendar-year CHIRPS v3 prelim data that the
+# forecasting-skills chirps-fetch-live skill uses. The current `chirps` /
+# `chirps_v3` accessors go through the cached `chirps_gridded` path, which
+# is cheaper for historical work but doesn't pick up the prelim file that
+# `chirps_raw_live` reads from data.chc.ucsb.edu/products/CHIRPS/v3.0/
+# daily/prelim/sat/netcdf/byYear/. Note: this function ignores its
+# start_time/end_time args and always returns the current calendar year.
+# Once exposed, the forecasting-skills `chirps-fetch-live` skill becomes
+# redundant and can be deleted.
 @dask_remote
 @spatial()
 @timeseries()

--- a/sheerwater/data/imerg.py
+++ b/sheerwater/data/imerg.py
@@ -11,6 +11,15 @@ from sheerwater.interfaces import data as sheerwater_data, spatial
 from .earthaccess_generic import earthaccess_dataset
 
 
+# TODO: Register imerg_raw_live as a sheerwater_data accessor (or add a
+# matching `imerg_live` wrapper that does) so the CLI / skills can expose
+# the same per-fetch live earthaccess path the forecasting-skills
+# imerg-fetch-live skill uses. The current `imerg` / `imerg_final` /
+# `imerg_late` accessors always go through the year-aggregated cache,
+# which is cheaper but doesn't cover the "I want today's data right now,
+# recompute=True, cache_mode=local_overwrite" use case the realtime
+# ingest pipeline needs. Once exposed, the forecasting-skills
+# `imerg-fetch-live` skill becomes redundant and can be deleted.
 @dask_remote
 @spatial()
 @timeseries()

--- a/sheerwater/data/tahmo.py
+++ b/sheerwater/data/tahmo.py
@@ -14,12 +14,33 @@ from sheerwater.interfaces import data as sheerwater_data
 @cache(cache_args=[])
 def tahmo_deployment():
     """Stub function to get deployment cache."""
+    # TODO: Implement live deployment fetch from the TAHMO API.
+    # Once this and tahmo_station_cleaned (below) are implemented, the
+    # forecasting-skills `tahmo-fetch-live` skill (the only working
+    # live-TAHMO path today) becomes redundant and can be deleted —
+    # sheerwater's `tahmo-fetch` skill will cover both cached and
+    # fresh-from-API fetches.
+    # Implementation should:
+    #   - Pull TAHMO API credentials via sheerwater.utils.secrets.tahmo_secret
+    #   - Call api.getStations() and pd.json_normalize the result
+    #   - Cache the normalized station deployment dataframe
+    # so this function returns the same shape currently expected by tahmo_raw().
     raise RuntimeError("Processing not implemented for tahmo_deployment and wasn't found in the cache.")
 
 
 @cache(cache_args=['station_id'], fail_if_no_cache=True)
 def tahmo_station_cleaned(station_id):  # noqa: ARG001
     """Stub function to get data cache."""
+    # TODO: Implement live per-station fetch from the TAHMO API. See the
+    # `tahmo_deployment` TODO above for the deletion-trigger note —
+    # forecasting-skills `tahmo-fetch-live` can be deleted once both
+    # are done.
+    # Implementation should:
+    #   - Pull TAHMO credentials via sheerwater.utils.secrets.tahmo_secret
+    #   - Call api.getRawData(station=station_id, dataset="controlled", ...)
+    #   - Filter to quality<=2, pick best-quality sensor per (time, variable)
+    #   - Resample to daily (sum for precip, mean for temp/humidity/pressure)
+    # so tahmo_raw_daily() can read it without going to the API.
     raise RuntimeError("Processing not implemented for tahmo_deployment and wasn't found in the cache.")
 
 

--- a/sheerwater/utils/data_utils.py
+++ b/sheerwater/utils/data_utils.py
@@ -24,6 +24,17 @@ def roll_and_agg(ds, agg, agg_col, agg_fn="mean", agg_thresh=None):
         agg_fn (str): Aggregation function. One of mean or sum.
         agg_thresh(int): number of data required to agg.
     """
+    # TODO: Add a calendar-aligned resampling sibling (e.g. resample_and_agg)
+    # so the skills/aggregate-temporal CLI can offer the calendar periods the
+    # forecasting-skills aggregate-temporal-resample skill supports
+    # (`monthly` in particular — calendar months can't be expressed as a
+    # fixed-day rolling window). Should accept
+    # period={'daily','weekly','dekadal','monthly'} and
+    # method={'sum','mean','max','min'}, dispatching to xarray.resample with
+    # the correct freq string ('1D', '7D', '10D', 'MS'). Keep roll_and_agg
+    # for the rolling case; new function for non-overlapping calendar windows.
+    # Once exposed via the CLI, the forecasting-skills
+    # `aggregate-temporal-resample` skill becomes redundant and can be deleted.
     if agg == 1:
         # If aggregation is 1 day, return the original dataset
         return ds
@@ -71,6 +82,15 @@ def regrid(ds, output_grid, method='conservative', base="base180", output_chunks
         region (str): The region to clip the data to.
         regridder_kwargs (dict): Additional keyword arguments for the regridder.
     """
+    # TODO: Add a coarsen-by-factor sibling (or extend regrid with a `factor`
+    # arg) so the skills/regrid CLI can offer the integer-factor and
+    # target-resolution downscaling the forecasting-skills `downscale-coarsen`
+    # skill supports. xarray.coarsen(boundary='trim'|'pad') with method=
+    # mean/sum/max/min/median is the underlying primitive. Useful when the
+    # caller doesn't care which named grid the result lands on, just wants
+    # "N times coarser than what I have" or "approximately X degrees".
+    # Once exposed via the CLI, the forecasting-skills `downscale-coarsen`
+    # skill becomes redundant and can be deleted.
     # Interpret the grid
     ds_out = get_grid_ds(output_grid, base=base)
     if region != 'global':

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,77 @@
+# Sheerwater Skills
+
+Agent skills (Agent Skills standard) that wrap the `sheerwater` CLI.
+
+Each skill is a `SKILL.md` documenting one logical verb against the CLI:
+
+- **Data fetch**: `chirps-fetch`, `imerg-fetch`, `tahmo-fetch`, `ghcn-fetch`,
+  `era5-fetch`, `tamsat-fetch`, `rain-over-africa-fetch`, `cbam-fetch`
+- **Forecast fetch**: `ecmwf-ifs-fetch`, `fuxi-fetch`, `graphcast-fetch`,
+  `gencast-fetch`, `salient-fetch`
+- **Ops**: `clip-region`, `regrid`, `aggregate-temporal`
+- **Eval**: `evaluate-forecast`, `compare-forecasts`
+
+All skills emit Rhiza Envelope-compliant Zarr stores (see
+[forecasting-skills/ENVELOPE.md](../../forecasting-skills/ENVELOPE.md)) so they
+compose with other envelope skills.
+
+## Install pattern
+
+The skills' single bin dependency is **`uv`** (declared in each SKILL.md's
+`metadata.openclaw.requires.bins`). Sheerwater itself is installed on demand
+from PyPI through `uvx`:
+
+```bash
+uvx sheerwater@latest <verb> <args>
+```
+
+`uvx` resolves the latest published `sheerwater` from PyPI on first call,
+caches it, and runs the registered `sheerwater` console script.
+
+### No version pinning
+
+Skills always invoke `sheerwater@latest` rather than a specific version.
+The trade-off is intentional, but consumers of these skills need to know it:
+
+- **What we lose:** when a consumer installs a skill (e.g. via
+  `skillkit install rhiza-research/sheerwater`), they get a snapshot
+  of SKILL.md whose example commands match whatever sheerwater shipped
+  at that moment. Later, when sheerwater publishes a release that
+  changes the CLI (renamed verbs, removed flags, changed defaults),
+  the consumer's next agent run will pull the new sheerwater via
+  `uvx sheerwater@latest` but their local SKILL.md snapshot still
+  references the old commands. The mismatch breaks the skill at
+  runtime. **A pin would have insulated the consumer from this** by
+  keeping their agent on the older sheerwater that matched their
+  snapshot.
+- **What we gain:** one less thing to maintain in this repo. No N-file
+  pin bumps per release, no risk of stale pins drifting out of sync.
+- **What this requires of consumers:** keep your installed skills
+  current with sheerwater. If a sheerwater release breaks a skill you
+  have installed, run `skillkit update` to refresh the SKILL.md
+  snapshot. The skill is updated in lockstep with the sheerwater
+  release in this repo.
+
+## Auth
+
+- Public sheerwater data (`gs://sheerwater-public-datalake/caches`) is readable
+  anonymously — `GOOGLE_APPLICATION_CREDENTIALS` is optional for these fetches.
+- Private bucket (`gs://sheerwater-datalake/caches`) requires
+  `GOOGLE_APPLICATION_CREDENTIALS` set to a GCP service-account JSON.
+
+All fetch and eval skills declare `GOOGLE_APPLICATION_CREDENTIALS` under
+`metadata.openclaw.requires.env` (with `primaryEnv` set to the same name). In
+the rhiza-agents runtime that field is informational/UX (used for the missing-
+credentials chip in the install UI and for the activation hint that tells the
+agent which secret name to attach to its `run_file` `credentials` argument). It
+does **not** gate skill selection — a user without the credential can still use
+public-bucket data because the agent passes credentials per call rather than
+having them injected unconditionally.
+
+Ops skills (`clip-region`, `regrid`, `aggregate-temporal`) operate on local
+Zarr files only and declare no env requirements.
+
+## Cache management
+
+Cache inspection and management is provided by the `nuthatch` CLI directly.
+Sheerwater does not re-export it. See `nuthatch --help`.

--- a/skills/aggregate-temporal/SKILL.md
+++ b/skills/aggregate-temporal/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: aggregate-temporal
+description: Apply a rolling temporal aggregation (mean or sum over an N-step window) to a Rhiza Envelope Zarr along the time or step axis. Use when you need to convert daily data to dekadal, weekly, or other rolling aggregates before evaluation or plotting.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+---
+
+# aggregate-temporal
+
+Rolling temporal aggregation, left-aligned. Backed by `sheerwater.utils.data_utils.roll_and_agg`. The aggregation coordinate must be `datetime64` (`time`) or `timedelta64` (`step`/`prediction_timedelta`).
+
+The aggregator drops the first `agg-1` slices (which would be all NaN) and shifts the remaining slices' coordinate values left by `agg-1` days so each window is labeled by its first day.
+
+## When to use
+
+- Converting daily envelope data to weekly/dekadal/monthly rolling aggregates.
+- Aligning a fine-cadence forecast to a coarser truth window before metric computation.
+
+## Usage
+
+```
+uvx sheerwater@latest ops aggregate \
+    --input <in.zarr> \
+    --agg N \
+    [--agg-col time|step] [--agg-fn mean|sum] [--agg-thresh K] \
+    --output <out.zarr>
+```
+
+### Key flags
+
+- `--input`, `-i` — input Zarr.
+- `--agg` — window length in coordinate steps (e.g. 7 for weekly daily input, 10 for dekadal).
+- `--agg-col` — coordinate to roll over. Default `time`. For forecasts use `prediction_timedelta` (or whatever step coordinate the input uses).
+- `--agg-fn` — `mean` (default) or `sum`. Use `sum` for precipitation totals; `mean` for state variables.
+- `--agg-thresh` — minimum number of valid (non-NaN) points required per window (default = `--agg`, i.e. require all points). Lower this to allow partial windows.
+
+### Output
+
+Zarr with the rolling aggregate applied. Stamped with `rhiza_aggregation` (e.g. `7-time-sum`).
+
+## Example
+
+```bash
+uvx sheerwater@latest ops aggregate --input /tmp/chirps_daily.zarr --agg 7 --agg-fn sum \
+    --output /tmp/chirps_weekly_sum.zarr
+```

--- a/skills/cbam-fetch/SKILL.md
+++ b/skills/cbam-fetch/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: cbam-fetch
+description: Fetch CBAM gridded daily precipitation and 2m temperature for a date range and write a Rhiza Envelope Zarr. Use when a task needs the CBAM dataset as gridded ground truth.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Public CBAM data reads from the sheerwater public bucket anonymously; set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# cbam-fetch
+
+CBAM is served from `gs://sheerwater-datalake/cbam-data/gap/cbam_20241021.zarr`. Sheerwater renames `total_rainfall` to `precip` and derives `tmp2m` as the mean of `min_total_temperature` and `max_total_temperature` from the source.
+
+The single registered dataset name is `cbam`.
+
+## Cache vs live fetch
+
+**There is no public live source for CBAM in sheerwater.** The loader reads directly from `gs://sheerwater-datalake/cbam-data/gap/cbam_20241021.zarr`, which lives in the sheerwater private datalake.
+
+- **Cache hit**: anonymous read from the public bucket if the requested aggregation has been computed and mirrored, works without credentials.
+- **Cache miss**: needs read access to the sheerwater private datalake (`gs://sheerwater-datalake/cbam-data/`). Set `GOOGLE_APPLICATION_CREDENTIALS` to a service account with that access, or run `gcloud auth application-default login` as a sheerwater-authorized user.
+
+## When to use
+
+- A task needs the CBAM dataset as observation truth.
+- Comparing a forecast against CBAM rainfall or temperature.
+
+## Usage
+
+```
+uvx sheerwater@latest data fetch cbam \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip|tmp2m] [--agg-days 1] \
+    [--grid global0_25] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — required; `precip` (daily mm) or `tmp2m` (°C; mean of source min/max).
+- `--agg-days` — required; rolling-mean window in days. Pass `--agg-days 1` for daily.
+- `--grid` — output grid (default `global0_25`); regridded conservatively from the source.
+
+See `uvx sheerwater@latest data fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with the requested variable, dims `(time, lat, lon)`, stamped with `rhiza_source=cbam`.
+
+## Example
+
+```bash
+uvx sheerwater@latest data fetch cbam --start 2024-01-01 --end 2024-03-31 \
+    --variable precip --region kenya --output /tmp/cbam_kenya.zarr
+```

--- a/skills/chirps-fetch/SKILL.md
+++ b/skills/chirps-fetch/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: chirps-fetch
+description: Fetch CHIRPS / CHIRP gridded precipitation observations from the Climate Hazards Center (UCSB) and write a Rhiza Envelope Zarr. Covers 5 dataset variants (CHIRPS v2/v3 with stations blended, CHIRP v2/v3 satellite-only, plus the canonical `chirps` alias). Use when a task needs CHIRPS rainfall as gridded ground truth.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Public CHIRPS data is read from the sheerwater public bucket anonymously; set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# chirps-fetch
+
+CHIRPS (Climate Hazards Center InfraRed Precipitation with Stations) is a quasi-global rainfall dataset combining satellite IR and station gauges, widely used as gridded precipitation truth in Africa. CHIRP (no S) is the satellite-only version of the same family.
+
+## Variants
+
+The CLI accepts these dataset names:
+
+| Name | Stations blended? | Version | Notes |
+|---|---|---|---|
+| `chirps` | yes | v3 | Alias for `chirps_v3` — the canonical pick |
+| `chirps_v3` | yes | v3 | Latest with-stations product. Valid from year 2000 onward |
+| `chirps_v2` | yes | v2 | Older with-stations product, longer historical record |
+| `chirp_v3` | no | v3 | Satellite-only v3. Valid from year 2000 onward |
+| `chirp_v2` | no | v2 | Satellite-only v2 |
+
+If you don't have a reason to pick a specific variant, use `chirps`.
+
+## Cache vs live fetch
+
+Every sheerwater fetch first checks the configured nuthatch caches (your local cache, the sheerwater datalake, and any configured mirrors including the public bucket). If a hit is found, the data comes from there. On a miss, sheerwater computes the result by hitting the live source.
+
+For CHIRPS:
+- **Cache hit (typical)**: anonymous, fast. Works without any credentials.
+- **Cache miss**: live fetch goes directly to UCSB's public HTTPS endpoint (`data.chc.ucsb.edu/products/CHIRPS/...` or `CHIRP/...`). No credentials needed for the live source either, but the network round-trips can be slow for long date ranges.
+
+So CHIRPS is fully self-serve regardless of cache state.
+
+### Need the current calendar year prelim file?
+
+This skill does NOT currently expose the CHIRPS v3 prelim file (`chirps_raw_live` in sheerwater) — only finalized historical CHIRPS. For prelim data within the current calendar year, use the `chirps-fetch-live` skill in the forecasting-skills repo. Once sheerwater registers the live accessor (TODO in `sheerwater.data.chirps`), this skill will cover both paths and the forecasting-skills version becomes redundant.
+
+## When to use
+
+- A task needs CHIRPS rainfall as gridded observations.
+- A downstream skill will clip, aggregate, regrid, or compare CHIRPS against another source.
+
+## Usage
+
+```
+uvx sheerwater@latest data fetch <name> \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip] [--agg-days 5] \
+    [--grid global0_25] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--start`, `--end` — inclusive date range. CHIRPS v3 variants only support dates from 2000 onward.
+- `--variable` — only `precip` is supported by CHIRPS / CHIRP.
+- `--agg-days` — rolling-mean window in days (default 5 for CHIRPS).
+- `--grid` — output grid (default `global0_25`). Native grid is `chirps` (~0.05° irregular); the underlying loader regrids onto your chosen grid using conservative regridding.
+- `--region` — named sheerwater region (default `global`).
+
+See `uvx sheerwater@latest data fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with `precip` (mm/day), dims `(time, lat, lon)`, stamped with `rhiza_source=<name>`.
+
+## Example
+
+```bash
+uvx sheerwater@latest data fetch chirps \
+    --start 2024-01-01 --end 2024-03-31 \
+    --region kenya --output /tmp/chirps_kenya.zarr
+```

--- a/skills/clip-region/SKILL.md
+++ b/skills/clip-region/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: clip-region
+description: Spatially subset a gridded Rhiza Envelope Zarr to a named sheerwater region (country, custom region, agroecological zone, etc.). Use when you need to restrict a dataset to a country or named area before downstream aggregation, plotting, or evaluation.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+---
+
+# clip-region
+
+Region-aware clipping using sheerwater's named regions and grid-aware spatial subdivisions. Backed by `sheerwater.spatial_subdivisions.clip_region`. The CLI passes a single region NAME (not a subdivision level) and sheerwater auto-detects which subdivision the name belongs to.
+
+## Region naming
+
+Regions live under one of these subdivision levels (defined in `spatial_subdivisions.py`):
+
+| Subdivision | Examples |
+|---|---|
+| `country` | `kenya`, `ethiopia`, `ghana`, `united_states_of_america`, ... (NaturalEarth `world_50m` admin-0 set, ~250 entries) |
+| `admin_1` | sub-national admin-1 boundaries; names are formatted `<country>-<admin1>` (e.g. `kenya-rift_valley`) |
+| `admin_2` | admin-2 boundaries; names are `<country>-<admin1>-<admin2>` |
+| `continent` | `africa`, `asia`, `europe`, ... (UN/WB world definitions) |
+| `subregion`, `region_un`, `region_wb` | Other UN/WB groupings |
+| `sheerwater_region` | Custom region groupings: `nimbus_east_africa` (kenya/burundi/rwanda/tanzania/uganda), `nimbus_west_africa` (16 W African countries), `conus` (USA) |
+| `meteorological_zone` | `tropics`, `extratropics_northern`, `extratropics_southern` |
+| `hemisphere` | `northern_hemisphere`, `southern_hemisphere` |
+| `agroecological_zone` | FAO AEZ classes, e.g. `tropics_lowland_humid`, `tropics_highland_semi-arid`, ... (33 classes plus no_region) |
+| `global` | `global` (the whole grid; this is a no-op) |
+
+Sheerwater normalizes region names: lowercases, replaces spaces with underscores, strips accents, and applies a small set of country-name aliases (e.g. `cote_d'ivoire` → `ivory_coast`, `swaziland` → `eswatini`). Pass the human name and sheerwater will reconcile.
+
+## When to use
+
+- Narrowing a global or continental envelope down to one country, region, or zone before plotting or per-region reporting.
+- Restricting any gridded envelope to a named region before downstream operations.
+
+## Usage
+
+```
+uvx sheerwater@latest ops clip \
+    --input <in.zarr> \
+    --region NAME \
+    --grid GRID \
+    --output <out.zarr>
+```
+
+### Key flags
+
+- `--input`, `-i` — input Zarr.
+- `--region` — region NAME (any of the names listed above; not a subdivision name).
+- `--grid` — grid the region is defined against (e.g. `global0_25`, `global1_5`, `global0_1`, `global0_05`, `salient0_25`). Must match the grid the input was fetched on, since the region masks are pre-computed per-grid.
+- `--output`, `-o` — output Zarr.
+
+### Output
+
+Same dims and variables as input, restricted to the requested region. Stamped with `rhiza_region`.
+
+## Example
+
+```bash
+uvx sheerwater@latest ops clip --input /tmp/era5.zarr --region kenya --grid global0_25 \
+    --output /tmp/era5_kenya.zarr
+```
+
+```bash
+# Clip to a custom multi-country region
+uvx sheerwater@latest ops clip --input /tmp/era5.zarr --region nimbus_east_africa --grid global0_25 \
+    --output /tmp/era5_east_africa.zarr
+```

--- a/skills/compare-forecasts/SKILL.md
+++ b/skills/compare-forecasts/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: compare-forecasts
+description: Compute a matrix of metrics for multiple forecasts against a single truth dataset. Use when you need to compare how several models perform on the same metrics over the same window/region.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Most cells of the matrix hit pre-computed results in the public sheerwater cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# compare-forecasts
+
+Compute a forecast × metric matrix against one truth source — produces a JSON table you can drop into a report or feed into a comparison plot.
+
+For the catalog of available metrics and their constraints (probabilistic vs deterministic, valid variables, categorical bin syntax), see the `evaluate-forecast` skill.
+
+## When to use
+
+- Benchmarking AI models (GraphCast / FuXi / GenCast) against an operational baseline (ECMWF IFS).
+- Producing a side-by-side skill comparison for a region/season.
+
+## Usage
+
+```
+uvx sheerwater@latest eval compare \
+    --forecasts NAME1,NAME2,... \
+    --truth NAME \
+    --metrics NAME1,NAME2,... \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [-v precip] [--agg-days 1] [--grid global1_5] [--mask lsm] [--region global] \
+    [-o matrix.json]
+```
+
+### Key flags
+
+- `--forecasts` — comma-separated forecast names.
+- `--truth` — truth dataset name.
+- `--metrics` — comma-separated metric names. Use the bin-suffix syntax (`heidke-1-5-10`) for categorical metrics.
+- `-o` / `--output` — JSON output path (default: stdout).
+
+Each cell of the matrix is computed via the same `sheerwater.metrics.metric` call as `eval metric`, so probabilistic-only metrics (`crps`, `brier`) require the corresponding forecast to be probabilistic, and metrics with `valid_variables=['precip']` will fail on non-precip evaluations.
+
+### Output
+
+JSON of the form:
+```json
+{
+  "truth": "chirps", "variable": "precip", "agg_days": 1, "grid": "global1_5", "region": "kenya",
+  "start_time": "2024-01-01", "end_time": "2024-03-31",
+  "matrix": {
+    "graphcast": { "mae": { ... }, "rmse": { ... } },
+    "fuxi":      { "mae": { ... }, "rmse": { ... } },
+    "ecmwf_ifs_er": { "mae": { ... }, "rmse": { ... } }
+  }
+}
+```
+
+## Example
+
+```bash
+uvx sheerwater@latest eval compare \
+    --forecasts graphcast,fuxi,ecmwf_ifs_er \
+    --truth chirps \
+    --metrics mae,rmse,bias \
+    --start 2024-01-01 --end 2024-03-31 \
+    --region kenya \
+    --output /tmp/compare_kenya.json
+```

--- a/skills/ecmwf-ifs-fetch/SKILL.md
+++ b/skills/ecmwf-ifs-fetch/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: ecmwf-ifs-fetch
+description: Fetch ECMWF IFS extended-range (sub-seasonal) forecast data for a date range and write a Rhiza Envelope Zarr. Covers the raw IFS-ER product and a sheerwater bias-corrected variant. Use when a task needs ECMWF S2S forecasts as a verification baseline.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Underlying data is read from WeatherBench2's public bucket (gs://weatherbench2/datasets/ifs_extended_range); set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private sheerwater cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# ecmwf-ifs-fetch
+
+ECMWF IFS-ER (Integrated Forecasting System Extended Range) is the operational sub-seasonal global forecast (46-day lead time). Sheerwater serves it from the WeatherBench2 mirror.
+
+## Variants
+
+The CLI accepts these dataset names:
+
+| Name | Bias-corrected? | Notes |
+|---|---|---|
+| `ecmwf_ifs_er` | no | Raw IFS-ER, ensemble-mean (`--prob-type deterministic`) or all 50 perturbed members (`--prob-type probabilistic`). |
+| `ecmwf_ifs_er_debiased` | yes | Reforecast-based bias correction with `margin_in_days=6`, computed against the 20-year reforecast hindcast and ERA5. |
+
+For verification against truth, prefer `ecmwf_ifs_er_debiased`. For the unmodified operational signal, use `ecmwf_ifs_er`.
+
+## When to use
+
+- A task needs ECMWF sub-seasonal forecasts as a baseline.
+- Comparing AI weather models (GraphCast, FuXi, GenCast) against the operational physical-model baseline.
+
+## Usage
+
+```
+uvx sheerwater@latest forecast fetch <name> \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip|tmp2m|tmax2m|tmin2m|ssrd] [--agg-days 1] \
+    [--prob-type deterministic|probabilistic] \
+    [--grid global1_5] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — variables with explicit unit handling: `precip` (mm), `tmp2m`/`tmax2m`/`tmin2m` (°C), `ssrd` (J/m²). Other variables in the variable map may pass through but won't get unit conversion.
+- `--agg-days` — rolling-mean window over the lead-time dimension (default 1).
+- `--prob-type` — `deterministic` (ensemble mean) or `probabilistic` (all 50 perturbed members).
+- `--grid` — `global1_5` (native; default). The loader can regrid to coarser grids (`>=1.5°`) but raises on finer grids. Reforecast regridding has a separate "use with care" warning in the source.
+
+See `uvx sheerwater@latest forecast fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with the requested variable, dims `(init_time, prediction_timedelta, lat, lon)` plus `member` for `--prob-type probabilistic`. Stamped with `rhiza_source=<name>` and `prob_type` attribute (`deterministic` or `ensemble`).
+
+## Example
+
+```bash
+uvx sheerwater@latest forecast fetch ecmwf_ifs_er --start 2024-01-01 --end 2024-03-31 \
+    --variable precip --region kenya --output /tmp/ecmwf_kenya.zarr
+```

--- a/skills/era5-fetch/SKILL.md
+++ b/skills/era5-fetch/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: era5-fetch
+description: Fetch ECMWF ERA5 reanalysis (precipitation, 2m temperature, radiation, humidity, ...) and write a Rhiza Envelope Zarr. Covers the global ARCO ERA5 product and the higher-resolution ERA5-Land. Use when a task needs the long-record reanalysis as gridded ground truth or a verification baseline.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. ERA5 reads from Google ARCO (gs://gcp-public-data-arco-era5) anonymously; ERA5-Land reads from Earth Data Hub via a sheerwater-managed token. GOOGLE_APPLICATION_CREDENTIALS is only needed for the sheerwater private cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# era5-fetch
+
+ERA5 is ECMWF's flagship global reanalysis (hourly from 1940 onward). Sheerwater serves daily-aggregated ERA5 from the Google ARCO mirror, plus the higher-resolution land-only ERA5-Land variant from Earth Data Hub.
+
+## Variants
+
+The CLI accepts these dataset names:
+
+| Name | Source | Native grid | Coverage |
+|---|---|---|---|
+| `era5` | Google ARCO ERA5 | 0.25° | Global, full atmospheric column |
+| `era5_land` | Earth Data Hub ERA5-Land | 0.1° | Land-only, finer detail |
+
+`era5_daily` and `era5_cds` exist in the codebase but are internal helpers, not registered for fetching.
+
+Pick `era5` for global comparisons or non-land variables. Pick `era5_land` when the question is land-focused and 0.1° detail matters; note `era5_land` cannot be regridded finer than 0.1°.
+
+## Cache vs live fetch
+
+For `era5`:
+- **Cache hit**: anonymous, fast.
+- **Cache miss**: live fetch reads from `gs://gcp-public-data-arco-era5/...` (Google ARCO public mirror). No credentials needed for the live source. Fully self-serve.
+
+For `era5_land`:
+- **Cache hit**: anonymous, fast.
+- **Cache miss**: live fetch goes to Earth Data Hub (`data.earthdatahub.destine.eu`) using a token sheerwater pulls from its own secret manager. Filling a cache miss requires GCP credentials with read access to sheerwater's secret manager. End users do not need their own Earth Data Hub token.
+
+## When to use
+
+- A task needs long-record gridded reanalysis truth.
+- Establishing a verification baseline against a forecast.
+
+## Usage
+
+```
+uvx sheerwater@latest data fetch <name> \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip|tmp2m|tmax2m|tmin2m|rh2m|ssrd|tcwv] [--agg-days 1] \
+    [--grid global0_25] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — for `era5`: `precip` (mm), `tmp2m` (mean), `tmax2m`, `tmin2m` (all °C), `rh2m` (%, derived from `d2m` + `tmp2m` via Magnus formula), `ssrd` (J/m², downward solar radiation), `tcwv` (kg/m², column water vapour). For `era5_land`: `precip`, `tmp2m`, `tmax2m`, `tmin2m`, `ssrd` only (no `rh2m`, no `tcwv`). Other variables raise. **For `era5_land`, --variable and --agg-days are required (no function-level defaults).**
+- `--agg-days` — rolling-mean window in days (default 1 for `era5`; required for `era5_land`).
+- `--grid` — output grid. ERA5 cannot regrid finer than 0.25°; ERA5-Land cannot regrid finer than 0.1°.
+
+See `uvx sheerwater@latest data fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with the requested variable, dims `(time, lat, lon)`, stamped with `rhiza_source=<name>`.
+
+## Example
+
+```bash
+uvx sheerwater@latest data fetch era5 --start 2024-01-01 --end 2024-03-31 \
+    --variable precip --region kenya --output /tmp/era5_kenya.zarr
+```

--- a/skills/evaluate-forecast/SKILL.md
+++ b/skills/evaluate-forecast/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: evaluate-forecast
+description: Compute a single verification metric (MAE, RMSE, bias, ACC, CRPS, Brier, Heidke, ETS, CSI, FAR, POD, frequency bias, MAPE/SMAPE, SEEPS, Pearson, MSE) for a forecast vs a truth dataset over a date range. Use when assessing how well one forecast model performs against a chosen ground-truth source.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Most metrics complete fast against the public sheerwater cache; cache misses require GOOGLE_APPLICATION_CREDENTIALS and may be slow (Dask cluster recommended).
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# evaluate-forecast
+
+Compute a verification metric for a forecast against a truth dataset. Backed by `sheerwater.metrics.metric` — most queries hit pre-computed results in the public sheerwater cache, returning in seconds.
+
+## Available metrics
+
+Pick `--metric <name>` from this catalog. The "valid variables" column says which forecast variables a metric will run on; passing an unsupported variable raises.
+
+| Metric | Type | Valid variables | Notes |
+|---|---|---|---|
+| `mae` | deterministic | all | Mean Absolute Error |
+| `mse` | deterministic | all | Mean Squared Error |
+| `rmse` | deterministic | all | sqrt of MSE |
+| `bias` | deterministic | all | Mean error (forecast − truth) |
+| `acc` | deterministic | all | Anomaly Correlation Coefficient vs ERA5 climatology (1990-2019) |
+| `crps` | probabilistic | all | Continuous Ranked Probability Score; requires probabilistic forecast |
+| `pearson` | deterministic | precip only | Pearson correlation (rewritten for grouped streaming) |
+| `mape` | deterministic | precip only | Mean Absolute Percentage Error |
+| `smape` | deterministic | precip only | Symmetric Mean Absolute Percentage Error |
+| `seeps` | deterministic | precip only | Stable Equitable Error in Probability Space; uses 1991-2020 climatology |
+| `brier` | probabilistic | precip only | Categorical Brier score; requires bins (see below) |
+| `heidke` | deterministic | precip only | Heidke Skill Score; categorical, requires bins |
+| `pod` | deterministic | precip only | Probability of Detection; categorical, requires bins |
+| `far` | deterministic | precip only | False Alarm Rate; categorical, requires bins |
+| `csi` | deterministic | precip only | Critical Success Index; categorical, requires bins |
+| `ets` | deterministic | precip only | Equitable Threat Score; categorical, requires bins |
+| `frequencybias` | deterministic | precip only | Frequency Bias; categorical, requires bins |
+
+### Categorical metrics: bin syntax
+
+For `brier`, `heidke`, `pod`, `far`, `csi`, `ets`, and `frequencybias`, the metric name needs bin thresholds appended with hyphens. For example, to compute Heidke with bins at 1, 5, and 10 mm:
+
+```
+--metric heidke-1-5-10
+```
+
+Bins are interpreted as the boundaries of the categories (with `-inf` and `+inf` automatically added at the ends). Up to 10 bins maximum.
+
+### Probabilistic vs deterministic
+
+`crps` and `brier` only run on probabilistic forecasts (the metric checks the forecast's `prob_type` attribute and raises on a mismatch). All other metrics require a deterministic forecast.
+
+## When to use
+
+- Quantifying forecast skill against a chosen truth source for a window/region.
+- Producing a JSON metric value to feed into a report or dashboard.
+- Producing a gridded residual field for downstream visualization.
+
+## Usage
+
+```
+uvx sheerwater@latest eval metric \
+    --forecast NAME --truth NAME --metric NAME \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [-v precip] [--agg-days 1] [--grid global1_5] [--mask lsm] [--region global] \
+    [--time-grouping NAME] [--space-grouping NAME] \
+    [--spatial | --zarr-output PATH] \
+    [-o output.json]
+```
+
+### Key flags
+
+- `--forecast` — forecast model name (see `sheerwater forecast list`).
+- `--truth` — truth dataset name (see `sheerwater data list`). Note: the metric framework also accepts forecast names here when comparing two forecasts.
+- `--metric` — metric name plus optional bin suffix for categorical metrics.
+- `--time-grouping` — group results by month/year/etc. (mapped through `groupby_time`).
+- `--space-grouping` — group results by a spatial subdivision name (e.g. `country`, `continent`, `admin_1`, `agroecological_zone`); default is `country`.
+- `--region` — clip the evaluation to a region NAME (e.g. `kenya`, `africa`, `nimbus_east_africa`). Sheerwater auto-detects which subdivision level the name belongs to.
+- `--spatial` — return a gridded result instead of grouped scalar/table.
+- `--zarr-output` — write gridded result as envelope Zarr (implies `--spatial`).
+- `-o` / `--output` — JSON output path (default: stdout).
+
+### Output
+
+JSON of the form:
+```json
+{
+  "forecast": "graphcast", "truth": "chirps", "metric": "mae",
+  "variable": "precip", "agg_days": 1, "grid": "global1_5", "region": "global",
+  "start_time": "2024-01-01", "end_time": "2024-03-31",
+  "values": { "precip": 1.234 }
+}
+```
+
+Or, with `--zarr-output`, an envelope Zarr of the gridded residuals.
+
+## Examples
+
+```bash
+# Scalar MAE for GraphCast vs CHIRPS over Q1 2024 in Kenya
+uvx sheerwater@latest eval metric --forecast graphcast --truth chirps --metric mae \
+    --start 2024-01-01 --end 2024-03-31 --region kenya
+```
+
+```bash
+# Heidke Skill Score with bins at 1, 5, 10 mm
+uvx sheerwater@latest eval metric --forecast ecmwf_ifs_er_debiased --truth chirps \
+    --metric heidke-1-5-10 --start 2024-01-01 --end 2024-03-31 --region africa
+```
+
+```bash
+# Gridded RMSE residuals
+uvx sheerwater@latest eval metric --forecast fuxi --truth era5 --metric rmse \
+    --start 2024-01-01 --end 2024-03-31 --region africa \
+    --zarr-output /tmp/fuxi_rmse.zarr
+```

--- a/skills/fuxi-fetch/SKILL.md
+++ b/skills/fuxi-fetch/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: fuxi-fetch
+description: Fetch FuXi AI weather model forecasts (precipitation or 2m temperature, deterministic ensemble mean or probabilistic ensemble) for a date range and write a Rhiza Envelope Zarr.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Underlying data is downloaded from the FudanFuXi/FuXi-S2S Hugging Face dataset; sheerwater handles the Hugging Face token internally. Set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private sheerwater cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# fuxi-fetch
+
+FuXi is Fudan University's S2S AI weather model. Sheerwater pulls per-day forecasts from the `FudanFuXi/FuXi-S2S` Hugging Face dataset and serves them on the 1.5° global grid.
+
+The single registered forecast name is `fuxi`.
+
+The raw FuXi files contain `tp, t2m, d2m, sst, ttr, 10u, 10v, msl, tcwv` channels, but only `precip` (mm/day, derived from `tp * 24`) and `tmp2m` (°C, derived from `t2m - 273.15`) get unit conversions in sheerwater's pipeline. Use `--variable precip` or `--variable tmp2m`.
+
+## When to use
+
+- A task needs FuXi forecasts for benchmarking against other AI models or operational baselines.
+- Building a multi-model comparison that includes FuXi.
+
+## Usage
+
+```
+uvx sheerwater@latest forecast fetch fuxi \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip|tmp2m] [--agg-days 1] \
+    [--prob-type deterministic|probabilistic] \
+    [--grid global1_5] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — `precip` (mm) or `tmp2m` (°C).
+- `--agg-days` — rolling-mean window over the lead-time dimension (default 1).
+- `--prob-type` — `deterministic` (averages over the 51 members) or `probabilistic` (keeps all members; output stamped `prob_type=ensemble`).
+- `--grid` — only `global1_5` is implemented (the loader raises on other grids).
+
+See `uvx sheerwater@latest forecast fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with the requested variable, dims `(init_time, prediction_timedelta, lat, lon)` plus `member` for `--prob-type probabilistic`. Stamped with `rhiza_source=fuxi`.
+
+## Example
+
+```bash
+uvx sheerwater@latest forecast fetch fuxi --start 2024-01-01 --end 2024-03-31 \
+    --variable tmp2m --region africa --output /tmp/fuxi_africa.zarr
+```

--- a/skills/gencast-fetch/SKILL.md
+++ b/skills/gencast-fetch/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: gencast-fetch
+description: Fetch DeepMind GenCast AI ensemble forecasts (precipitation only, deterministic mean or probabilistic ensemble) for a date range and write a Rhiza Envelope Zarr.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Underlying data is read from public WeatherNext buckets; set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private sheerwater cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# gencast-fetch
+
+GenCast is DeepMind's diffusion-based ensemble AI weather model. Sheerwater reads the WeatherNext archive (`gs://weathernext/126478713_1_0/zarr/...`) and concatenates the 2020, 2021, and 2022 init-year archives. Initialisation dates outside that span (including 2023, which exists in the source repo but is NOT included by sheerwater's loader) will produce no data.
+
+The single registered forecast name is `gencast`. Currently only `precip` is implemented; the loader raises on other variables (a known data quality issue with non-precip GenCast variables in the sheerwater cache).
+
+## When to use
+
+- A task needs probabilistic precipitation forecasts (e.g. for CRPS/Brier-type metrics).
+- Comparing ensemble AI models against ECMWF ENS or other ensembles.
+
+## Usage
+
+```
+uvx sheerwater@latest forecast fetch gencast \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    --variable precip [--agg-days 1] \
+    [--prob-type deterministic|probabilistic] \
+    [--grid global1_5] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — only `precip` is supported.
+- `--agg-days` — rolling-mean window over the lead-time dimension (default 1).
+- `--prob-type` — `deterministic` (averages over the ensemble members) or `probabilistic` (keeps all members; output stamped `prob_type=ensemble`).
+- `--grid` — `global1_5` is the top-level default; the underlying daily fetch is on `global0_25` and regrids conservatively to other grids.
+
+See `uvx sheerwater@latest forecast fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with `precip`, dims `(init_time, prediction_timedelta, lat, lon)` plus `member` for `--prob-type probabilistic`. Stamped with `rhiza_source=gencast`.
+
+## Example
+
+```bash
+uvx sheerwater@latest forecast fetch gencast --start 2021-01-01 --end 2021-03-31 \
+    --variable precip --region africa --output /tmp/gencast_africa.zarr
+```

--- a/skills/ghcn-fetch/SKILL.md
+++ b/skills/ghcn-fetch/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: ghcn-fetch
+description: Fetch NOAA GHCN-Daily station observations gridded onto a regular lat/lon grid, with a choice of one-station-per-cell or per-cell averaging. Use when a task needs station-level historical precipitation or temperature as ground truth.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Underlying data is read anonymously from NOAA's public S3 bucket (s3://noaa-ghcn-pds); set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private sheerwater cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# ghcn-fetch
+
+The Global Historical Climatology Network – Daily (NOAA GHCN-D) is a long-record source of in-situ daily precipitation and temperature observations worldwide. Sheerwater reads station inventories from the GHCN public S3 bucket, snaps stations to the requested grid, and either keeps one representative station per cell (`first`) or averages all stations in a cell (`avg`).
+
+The underlying loader pulls these GHCN measurement codes: `TMAX`, `TMIN`, `TAVG`, `PRCP`. Sheerwater's exposed variables map onto:
+
+- `precip` — daily total precipitation (mm)
+- `tmp2m` (also accepted as `temp`) — daily mean temperature (°C). When `TAVG` is missing, sheerwater computes it as `(TMIN + TMAX) / 2`.
+
+Other temperature variables in the variable map (`tmax2m`, `tmin2m`) are NOT registered for GHCN — pass `tmp2m` for daily mean.
+
+## Variants
+
+The CLI accepts these dataset names:
+
+| Name | Per-cell aggregation |
+|---|---|
+| `ghcn` | first station only |
+| `ghcn_avg` | mean of all stations in the cell |
+
+Pick `ghcn` when you want one consistent station's record per cell. Pick `ghcn_avg` when you want a smoothed cell-level signal that uses every available station.
+
+## Cache vs live fetch
+
+Every sheerwater fetch first checks the configured nuthatch caches; on a miss it computes from the live source.
+
+For GHCN:
+- **Cache hit (typical)**: anonymous, fast.
+- **Cache miss**: live fetch reads `s3://noaa-ghcn-pds/csv/by_year/{year}.csv` with `storage_options={"anon": True}`. NOAA's S3 bucket is public, so no credentials are needed for the live source either. Long date ranges may be slow.
+
+GHCN is fully self-serve regardless of cache state.
+
+## When to use
+
+- A task needs station-level historical observations gridded for comparison with forecasts or reanalyses.
+- Verifying a long-record reanalysis against in-situ measurements.
+
+## Usage
+
+```
+uvx sheerwater@latest data fetch <name> \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip|tmp2m] [--agg-days 1] \
+    [--grid global0_25] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — `precip` (mm) or `tmp2m` (°C, accepts `temp` as an alias).
+- `--agg-days` — rolling-mean window in days (default 1). The loader applies a sufficient-coverage threshold of 90% (`missing_thresh=0.9`) by default.
+- `--grid` — output grid (default `global0_25`).
+
+See `uvx sheerwater@latest data fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with the requested variable plus a companion `<variable>_count` (count of valid station-days in each cell). Stamped with `rhiza_source=<name>` and `sparse=True` (most cells have no stations).
+
+## Example
+
+```bash
+uvx sheerwater@latest data fetch ghcn --start 1990-01-01 --end 2024-12-31 \
+    --variable tmp2m --output /tmp/ghcn_tmp.zarr
+```

--- a/skills/graphcast-fetch/SKILL.md
+++ b/skills/graphcast-fetch/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: graphcast-fetch
+description: Fetch DeepMind GraphCast AI weather model forecasts (precipitation or 2m temperature, deterministic only) for a date range and write a Rhiza Envelope Zarr. Use when a task needs GraphCast as a baseline AI model for verification.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Underlying data is read from public WeatherBench2 buckets; set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private sheerwater cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# graphcast-fetch
+
+GraphCast is DeepMind's graph-neural-network medium-range global weather model. Sheerwater serves it from the WeatherBench2 mirror (`gs://weatherbench2/datasets/graphcast/`). The underlying source covers initialisation dates in the range 2017-11-16 through 2021-02-01.
+
+The single registered forecast name is `graphcast`. Only deterministic forecasts are implemented (the loader raises on `--prob-type probabilistic`).
+
+## When to use
+
+- A task needs GraphCast as a baseline AI model.
+- Building a multi-model verification that includes GraphCast.
+
+## Usage
+
+```
+uvx sheerwater@latest forecast fetch graphcast \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip|tmp2m] [--agg-days 1] \
+    [--prob-type deterministic] \
+    [--grid global0_25|global1_5] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — only `precip` (mm) or `tmp2m` (°C). Other variables raise.
+- `--agg-days` — rolling-mean window over the lead-time dimension (default 1).
+- `--prob-type` — must be `deterministic`.
+- `--grid` — `global0_25` (native) or `global1_5` (regridded conservatively at the source). Other grids raise.
+
+See `uvx sheerwater@latest forecast fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with the requested variable, dims `(init_time, prediction_timedelta, lat, lon)`. Stamped with `rhiza_source=graphcast` and `prob_type=deterministic`.
+
+## Example
+
+```bash
+uvx sheerwater@latest forecast fetch graphcast --start 2020-01-01 --end 2020-12-31 \
+    --variable precip --region kenya --output /tmp/graphcast_kenya.zarr
+```

--- a/skills/imerg-fetch/SKILL.md
+++ b/skills/imerg-fetch/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: imerg-fetch
+description: Fetch GPM IMERG satellite-derived daily precipitation and write a Rhiza Envelope Zarr. Covers the late (near-realtime) and final (research-quality) runs, plus a canonical `imerg` alias. Use when a task needs IMERG rainfall as gridded ground truth.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Public data reads anonymously; GOOGLE_APPLICATION_CREDENTIALS only needed for the private cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# imerg-fetch
+
+GPM IMERG (Integrated Multi-satellitE Retrievals for GPM) is NASA's satellite-derived global precipitation product. Sheerwater serves the daily-aggregated form on a 0.1° native grid (regridded as requested).
+
+## Variants
+
+The CLI accepts these dataset names:
+
+| Name | Underlying product | Latency | Notes |
+|---|---|---|---|
+| `imerg` | GPM_3IMERGDF | ~3.5 months | Alias for `imerg_final` |
+| `imerg_final` | GPM_3IMERGDF | ~3.5 months | Research-quality run, gauge-corrected |
+| `imerg_late` | GPM_3IMERGDL | ~half day | Near-realtime, no gauge correction |
+
+Pick `imerg_final` for retrospective verification work; pick `imerg_late` when recency matters and reduced accuracy is acceptable.
+
+## Cache vs live fetch
+
+Every sheerwater fetch first checks the configured nuthatch caches; on a miss it computes from the live source.
+
+For IMERG:
+- **Cache hit (typical)**: anonymous, fast. Works without any credentials against the public bucket.
+- **Cache miss**: live fetch goes through NASA Earthaccess. Sheerwater pulls EARTHDATA credentials from its own secret manager — which means filling a cache miss requires GCP credentials with read access to sheerwater's secret manager (i.e. `GOOGLE_APPLICATION_CREDENTIALS` set to a service account on the sheerwater project, or `gcloud auth application-default login` as a sheerwater-authorized user). End users do NOT need their own EARTHDATA account.
+
+If you want to verify against a recent date range that may not be cached yet (especially `imerg_late`), expect to need sheerwater GCP credentials.
+
+### Need data fresher than the cache?
+
+This skill always reads from the year-aggregated cache first. For a per-fetch live earthaccess path that bypasses the cache (`recompute=True`, `cache_mode="local_overwrite"` — useful for realtime monitoring of `imerg_late` within the last few days), use the `imerg-fetch-live` skill in the forecasting-skills repo. That skill needs your own EARTHDATA_USERNAME / EARTHDATA_PASSWORD instead of routing through sheerwater's secret manager. Once sheerwater registers the live accessor (TODO in `sheerwater.data.imerg`), this skill will cover both paths and the forecasting-skills version becomes redundant.
+
+## When to use
+
+- A task needs IMERG rainfall as gridded observations.
+- Verifying a global or African forecast against a satellite-derived truth.
+
+## Usage
+
+```
+uvx sheerwater@latest data fetch <name> \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip] [--agg-days 1] \
+    [--grid global0_25] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — only `precip` is supported.
+- `--agg-days` — rolling-mean window in days (default 1).
+- `--grid` — output grid (default `global0_25`). Native is `global0_1`.
+
+See `uvx sheerwater@latest data fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with `precip` (mm/day), dims `(time, lat, lon)`, stamped with `rhiza_source=<name>`.
+
+## Example
+
+```bash
+uvx sheerwater@latest data fetch imerg --start 2024-01-01 --end 2024-03-31 \
+    --region ethiopia --output /tmp/imerg_ethiopia.zarr
+```

--- a/skills/knust-fetch/SKILL.md
+++ b/skills/knust-fetch/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: knust-fetch
+description: Fetch KNUST West-African rain-gauge station observations (Ashanti, DACCIWA, FuriFlood/Kumasi networks combined) gridded onto a regular lat/lon grid, with a choice of one-station-per-cell or per-cell averaging. Use when a task needs West-African in-situ rainfall as ground truth.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Underlying KNUST data lives at gs://sheerwater-datalake/knust_stations/; set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# knust-fetch
+
+KNUST is a combined rain-gauge dataset assembled by Kwame Nkrumah University of Science and Technology (Ghana), built from three station collections:
+
+- Ashanti Region network (Ghana)
+- DACCIWA project rain gauges (West Africa multi-country research network)
+- FuriFlood Kumasi rain gauges (Ghana)
+
+Sheerwater merges them, snaps stations to the requested grid, and either keeps one representative station per cell (`first`) or averages all stations in a cell (`avg`).
+
+## Cache vs live fetch
+
+**There is no live API for KNUST.** The underlying loaders read NetCDF files directly from `gs://sheerwater-datalake/knust_stations/` (Ashanti, DACCIWA, FuriFlood subdirectories). Coverage is whatever those files contain.
+
+- **Cache hit**: anonymous read from the public bucket if the result has been computed and mirrored, works without credentials.
+- **Cache miss**: the loader needs read access to `gs://sheerwater-datalake/knust_stations/` to ingest the source files. If that path isn't readable for your GCP identity (it's the private datalake), the call will fail.
+
+In practice this means cached aggregates work for everyone; first-time computations on un-cached date ranges need sheerwater GCP credentials.
+
+## Variants
+
+The CLI accepts these dataset names:
+
+| Name | Per-cell aggregation |
+|---|---|
+| `knust` | first station only |
+| `knust_avg` | mean of all stations in the cell |
+
+## When to use
+
+- A task needs West-African station-level rainfall as ground truth, especially in Ghana.
+- Comparing forecasts or satellite products against the KNUST station network.
+
+## Usage
+
+```
+uvx sheerwater@latest data fetch <name> \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip] [--agg-days 1] \
+    [--grid global0_25] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — only `precip` is supported (daily mm).
+- `--agg-days` — rolling-mean window in days (default 1).
+- `--grid` — output grid (default `global0_25`).
+
+See `uvx sheerwater@latest data fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with `precip` (mm/day) plus a companion `precip_count` (number of valid station-days in each cell). Stamped with `rhiza_source=<name>` and `sparse=True`.
+
+## Example
+
+```bash
+uvx sheerwater@latest data fetch knust --start 2018-01-01 --end 2019-12-31 \
+    --region ghana --output /tmp/knust_ghana.zarr
+```

--- a/skills/oya-fetch/SKILL.md
+++ b/skills/oya-fetch/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: oya-fetch
+description: Fetch the Oya global precipitation nowcast product (Google Earth Engine, 30-minute cadence aggregated to daily) for a date range and write a Rhiza Envelope Zarr. Use when a task needs the Oya rainfall product as ground truth.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Oya is sourced from Google Earth Engine (sheerwater initializes EE internally with project='sheerwater'); set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private sheerwater cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# oya-fetch
+
+Oya is a global precipitation nowcast product served from the Google Earth Engine asset `projects/global-precipitation-nowcast/assets/global_estimation`. The native cadence is 30 minutes; sheerwater aggregates to daily totals (mm).
+
+The single registered dataset name is `oya`.
+
+The loader filters out infinities and daily totals exceeding 1000 mm as bad data.
+
+## Cache vs live fetch
+
+- **Cache hit**: anonymous, fast.
+- **Cache miss**: live fetch goes to Google Earth Engine via `ee.Initialize(project='sheerwater', ...)`. This requires Earth Engine access registered against the sheerwater GCP project, which means GCP credentials with that role. End users without sheerwater EE access cannot fill cache misses; they can only read pre-computed aggregations from the public bucket.
+
+## When to use
+
+- A task needs the Oya satellite-derived rainfall product as observations.
+
+## Usage
+
+```
+uvx sheerwater@latest data fetch oya \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip] [--agg-days 1] \
+    [--grid global0_25] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — required; only `precip` is supported (daily mm).
+- `--agg-days` — required; rolling-mean window in days. Pass `--agg-days 1` for daily.
+- `--grid` — required; pass `source` to keep the native Earth Engine projection, otherwise a sheerwater grid name (e.g. `global0_25`) for conservative regridding.
+
+See `uvx sheerwater@latest data fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with `precip` (mm/day), dims `(time, lat, lon)`, stamped with `rhiza_source=oya`.
+
+## Example
+
+```bash
+uvx sheerwater@latest data fetch oya --start 2024-01-01 --end 2024-03-31 \
+    --region africa --output /tmp/oya_africa.zarr
+```

--- a/skills/rain-over-africa-fetch/SKILL.md
+++ b/skills/rain-over-africa-fetch/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: rain-over-africa-fetch
+description: Fetch the Rain Over Africa (rainoverafrica.ai) daily precipitation product, derived from MSG geostationary satellite imagery, for a date range and write a Rhiza Envelope Zarr. Use when a task needs the ROA Africa rainfall product as ground truth.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Underlying ROA data is in the sheerwater datalake; set GOOGLE_APPLICATION_CREDENTIALS for private access.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# rain-over-africa-fetch
+
+Rain Over Africa (ROA) is a satellite-derived daily rainfall product over Africa, produced from MSG geostationary observations at 15-minute cadence and aggregated to daily totals. See [rainoverafrica.ai](https://rainoverafrica.ai/).
+
+The single registered dataset name is `rain_over_africa`.
+
+The loader treats any day where the spatial-max precip exceeds 350 mm/day as bad — that whole day is set to NaN across the grid (per the source comment, the threshold catches a class of corrupted values).
+
+## Cache vs live fetch
+
+**There is no public live source for ROA in sheerwater.** The loader reads per-day MSG files directly from `gs://sheerwater-datalake/rain_over_africa/`, the sheerwater private datalake.
+
+- **Cache hit**: anonymous read from the public bucket if the requested aggregation has been computed and mirrored, works without credentials.
+- **Cache miss**: needs read access to the sheerwater private datalake. Set `GOOGLE_APPLICATION_CREDENTIALS` to a service account with that access.
+
+## When to use
+
+- A task needs an African satellite-derived rainfall product as observations.
+- Comparing forecasts and other rainfall products against a continent-specific truth.
+
+## Usage
+
+```
+uvx sheerwater@latest data fetch rain_over_africa \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip] [--agg-days 1] \
+    [--grid global0_25] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — only `precip` is supported (daily mm).
+- `--agg-days` — rolling-mean window in days (default 1).
+- `--grid` — output grid (default `global0_25`); regridded conservatively from the source.
+
+See `uvx sheerwater@latest data fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with `precip` (mm/day), dims `(time, lat, lon)`, stamped with `rhiza_source=rain_over_africa`. The underlying source also produces `max_probability_precip` per day; only `precip` is exposed by the standard fetch.
+
+## Example
+
+```bash
+uvx sheerwater@latest data fetch rain_over_africa --start 2024-01-01 --end 2024-03-31 \
+    --region africa --output /tmp/roa_africa.zarr
+```

--- a/skills/regrid/SKILL.md
+++ b/skills/regrid/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: regrid
+description: Regrid a gridded Rhiza Envelope Zarr to a different sheerwater grid (e.g. global0_25 → global1_5), with a choice of regridding methods. Use when two datasets need to be on the same grid before per-cell comparison, or when reducing spatial detail for faster downstream steps.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+---
+
+# regrid
+
+Spatial regridding using `xarray-regrid`. Backed by `sheerwater.utils.data_utils.regrid`. Targets sheerwater's named grids.
+
+## Available grids
+
+| Grid name | Resolution | Notes |
+|---|---|---|
+| `global0_05` | 0.05° | Finest currently-defined sheerwater grid |
+| `global0_1` | 0.1° | IMERG / ERA5-Land native |
+| `global0_25` | 0.25° | ERA5 ARCO native; common default |
+| `global1_5` | 1.5° | ECMWF / FuXi / GenCast / GraphCast (fine path) native |
+| `salient0_25` | 0.25° | Salient grid offset variant |
+
+Plus dataset-specific named grids accepted by the source loaders (`tamsat`, `chirps`, `source` for native).
+
+## Methods
+
+`--method` selects the regridding algorithm:
+
+- `linear` — bilinear interpolation
+- `nearest` — nearest neighbor
+- `cubic` — cubic interpolation
+- `conservative` — area-weighted; preferred for flux-like fields (precipitation, radiation)
+- `most_common` — modal value; preferred for categorical fields (region labels, AEZ classes)
+
+## When to use
+
+- Putting two datasets on the same grid before per-cell comparison or metric computation.
+- Reducing spatial resolution for faster plotting or aggregation.
+- Increasing apparent resolution for visualization (interpolation only — does not produce new fine-scale information).
+
+## Usage
+
+```
+uvx sheerwater@latest ops regrid \
+    --input <in.zarr> \
+    --grid OUTPUT_GRID \
+    [--method conservative] [--base base180] [--region global] \
+    --output <out.zarr>
+```
+
+### Key flags
+
+- `--input`, `-i` — input Zarr.
+- `--grid` — output grid name from the table above.
+- `--method` — `linear`, `nearest`, `cubic`, `conservative` (default), or `most_common`.
+- `--base` — longitude base of the output grid: `base180` (default, [-180, 180]) or `base360` ([0, 360]).
+- `--region` — clip the output grid to a region after regridding (default `global`).
+
+### Output
+
+Zarr on the new grid with the same variables.
+
+## Example
+
+```bash
+uvx sheerwater@latest ops regrid --input /tmp/era5_0_25.zarr --grid global1_5 --method conservative \
+    --output /tmp/era5_1_5.zarr
+```

--- a/skills/salient-fetch/SKILL.md
+++ b/skills/salient-fetch/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: salient-fetch
+description: Fetch Salient Predictions sub-seasonal to seasonal (S2S) forecasts and write a Rhiza Envelope Zarr. Covers the global Salient blend and the East-Africa-only GEM v2 variant. Use when a task needs S2S/seasonal probabilistic forecasts.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Underlying Salient data is in the sheerwater datalake / Salient-managed object stores; set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private sheerwater cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# salient-fetch
+
+Salient Predictions is a commercial sub-seasonal to seasonal (S2S) forecast provider focused on weeks-to-months horizons. Sheerwater serves Salient forecasts in two registered forms:
+
+## Variants
+
+The CLI accepts these forecast names:
+
+| Name | Coverage | Default region | Default grid | Probabilistic? | Notes |
+|---|---|---|---|---|---|
+| `salient` | Global blend | africa | global0_25 | yes (quantile members) | `--agg-days` controls timescale: 7 = sub-seasonal, 30 = seasonal, 90 = long-range. Other agg_days values raise. |
+| `salient_gem` | East Africa | eastern_africa | global1_5 | no (deterministic only) | GEM v2 product from `s3://nimbus-gemv2/east_africa.zarr`; loader raises on probabilistic. 126-day forecast horizon. |
+
+## When to use
+
+- A task needs S2S/seasonal forecasts (weeks-to-months lead).
+- Comparing sub-seasonal forecast skill across providers.
+
+## Usage
+
+```
+uvx sheerwater@latest forecast fetch <name> \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip|tmp2m] [--agg-days 7|30|90] \
+    [--prob-type deterministic|probabilistic] \
+    [--grid global0_25|global1_5] [--mask lsm] [--region africa] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — `precip` and `tmp2m` are the variables Salient supports through sheerwater's variable map.
+- `--agg-days` — for `salient`: must be 7 (sub-seasonal weekly leads), 30 (seasonal monthly leads), or 90 (long-range quarterly leads). For `salient_gem`: any window over the 126-day forecast.
+- `--prob-type` — `salient` supports `deterministic` (selects the 0.5 quantile) or `probabilistic` (keeps all quantile members; output stamped `prob_type=quantile`). `salient_gem` is deterministic only.
+- `--grid` — `salient` defaults to `global0_25`; `salient_gem` defaults to `global1_5`.
+- `--region` — `salient` defaults to `africa`; `salient_gem` defaults to `eastern_africa` and is restricted to East Africa by the underlying data.
+
+See `uvx sheerwater@latest forecast fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with the requested variable, dims `(init_time, prediction_timedelta, lat, lon)` plus `member` for probabilistic. Stamped with `rhiza_source=<name>` and `prob_type` attribute (`deterministic` for the median, `quantile` for `salient` probabilistic, `ensemble` for `salient_gem` probabilistic — note `salient_gem` actually raises before reaching the probabilistic path).
+
+## Example
+
+```bash
+uvx sheerwater@latest forecast fetch salient --start 2024-01-01 --end 2024-12-31 \
+    --variable precip --agg-days 7 --region africa --output /tmp/salient_africa.zarr
+```

--- a/skills/smap-fetch/SKILL.md
+++ b/skills/smap-fetch/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: smap-fetch
+description: Fetch NASA SMAP soil-moisture observations (L3 passive radiometer or L4 surface+rootzone assimilated) for a date range and write a Rhiza Envelope Zarr. Use when a task needs satellite-derived soil moisture as ground truth or as input to a downstream analysis.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. SMAP data is fetched via NASA Earthaccess (sheerwater holds the credentials internally); set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private sheerwater cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# smap-fetch
+
+NASA SMAP (Soil Moisture Active Passive) provides global soil-moisture observations on the EASE Grid. Sheerwater serves two products:
+
+## Variants
+
+The CLI accepts these dataset names:
+
+| Name | Underlying product | Notes |
+|---|---|---|
+| `smap_l3` | SPL3SMP_E | Level-3 enhanced passive retrieval, AM and PM passes averaged. ~1-2 day pass rate per location. |
+| `smap_l4` | SPL4SMGP | Level-4 model-assimilated product, includes both `sm_surface` and `sm_rootzone`. |
+
+Pick `smap_l3` when you want direct satellite measurements; pick `smap_l4` for the model-assimilated product with rootzone information.
+
+## Cache vs live fetch
+
+- **Cache hit**: anonymous, fast.
+- **Cache miss**: live fetch goes through NASA Earthaccess (same path as IMERG). Sheerwater pulls EARTHDATA credentials from its own secret manager, so filling a cache miss requires GCP credentials with read access to sheerwater's secret manager. End users do NOT need their own EARTHDATA account.
+
+## When to use
+
+- A task needs satellite-derived soil moisture as observations.
+- Using soil moisture as predictor or evaluation context for forecasts.
+
+## Usage
+
+```
+uvx sheerwater@latest data fetch <name> \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable soil_moisture] [--agg-days 1] \
+    [--grid source] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — must be `soil_moisture` (the loader raises on anything else). For `smap_l4` this is essentially a sanity check; the actual output contains the underlying L4 variables.
+- `--agg-days` — rolling-mean window in days (default 1).
+- `--grid` — must be `source` (the EASE Grid). Regridding to standard lat/lon grids is not currently supported (the loader raises if you ask for one).
+
+See `uvx sheerwater@latest data fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr indexed by EASE-Grid `(y, x)` with `lat(y, x)` and `lon(y, x)` 2D coordinates. Variable contents differ by product:
+
+- `smap_l3`: a single `soil_moisture` variable, computed as the mean of the AM and PM passes.
+- `smap_l4`: two variables, `sm_surface` and `sm_rootzone` (the L4 product's surface and rootzone fields, both retained).
+
+Stamped with `rhiza_source=<name>`.
+
+## Example
+
+```bash
+uvx sheerwater@latest data fetch smap_l3 --start 2024-01-01 --end 2024-03-31 \
+    --grid source --output /tmp/smap_l3.zarr
+```

--- a/skills/stations-fetch/SKILL.md
+++ b/skills/stations-fetch/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: stations-fetch
+description: Fetch a unified station-observation dataset that merges GHCN, TAHMO, and KNUST into a single per-cell averaged grid, weighting each source by station count per cell. Use when a task needs the most complete station-derived ground truth available across Africa and globally.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Underlying station data is read from public bucket; set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# stations-fetch
+
+`stations` is sheerwater's unified station-observation accessor. Behavior depends on the grid:
+
+- For a regular grid (e.g. `--grid global0_25`): pulls per-cell averages from `ghcn_avg`, `tahmo_avg`, and `knust_avg`, then combines them in a station-count-weighted average per (time, lat, lon) cell. Cells with more contributing stations dominate, but cells covered by only one source still get values.
+- For `--grid source`: concatenates the raw per-station observations from `ghcn`, `tahmo`, and `knust` along the `station_id` dimension (no weighting; just the union).
+
+The single registered dataset name is `stations`.
+
+This is generally the right pick if you want "the best station-derived ground truth available for this place" without having to choose between GHCN, TAHMO, or KNUST. If you need to know which source contributed, fetch them individually instead.
+
+## When to use
+
+- A task needs broad station-derived ground truth and you don't care which network the value came from.
+- Verifying a forecast against in-situ data with the widest station coverage available.
+
+## Usage
+
+```
+uvx sheerwater@latest data fetch stations \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip|tmp2m|temp] [--agg-days 1] \
+    [--grid global0_25] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — `precip` (all three sources support it). Temperature variables are only contributed by GHCN among the three sources, so `--variable tmp2m`/`temp` will reflect GHCN coverage only.
+- `--agg-days` — rolling-mean window in days (default 1).
+- `--grid` — output grid (default `global0_25`).
+
+See `uvx sheerwater@latest data fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with the requested variable plus a companion `<variable>_count`. Stamped with `rhiza_source=stations` and `sparse=True`.
+
+## Example
+
+```bash
+uvx sheerwater@latest data fetch stations --start 2024-01-01 --end 2024-12-31 \
+    --variable precip --region africa --output /tmp/stations_africa.zarr
+```

--- a/skills/tahmo-fetch/SKILL.md
+++ b/skills/tahmo-fetch/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: tahmo-fetch
+description: Fetch TAHMO weather-station precipitation observations across Africa, gridded onto a regular lat/lon grid with a choice of one-station-per-cell or per-cell averaging. Use when a task needs African station-level rainfall as ground truth.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Underlying TAHMO station data is pre-cleaned in the sheerwater cache; reads work against the public bucket anonymously, set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# tahmo-fetch
+
+TAHMO (Trans-African Hydro-Meteorological Observatory) operates a network of automatic weather stations across Africa. Sheerwater consumes pre-cleaned TAHMO station files (QC-filtered to `precip_quality_flag > 0.9`) and snaps stations to the requested grid, either keeping one station per cell (`first`) or averaging all stations in a cell (`avg`).
+
+## Cache vs live fetch
+
+**TAHMO is cache-only in sheerwater.** Unlike CHIRPS or IMERG, sheerwater does NOT have a live-fetch path to the TAHMO API. The underlying `tahmo_deployment` and `tahmo_station_cleaned` functions are stubs that raise `RuntimeError("Processing not implemented...")` whenever the cache misses. A separate ingest pipeline (run by sheerwater operators with TAHMO API credentials) populates these caches out-of-band.
+
+Practically:
+- **Cache hit**: anonymous read from the public bucket, works without credentials.
+- **Cache miss**: the call FAILS. There is no fallback. Either the date range / station ID hasn't been ingested yet, or the cache was rotated.
+
+### Need data not in the sheerwater cache?
+
+Use the `tahmo-fetch-live` skill in the forecasting-skills repo. It calls the TAHMO REST API directly via the tahmo-api SDK and works for any date range, but requires your own TAHMO_API_USERNAME / TAHMO_API_PASSWORD. That skill is the only working live-TAHMO path today. Once sheerwater implements its live TAHMO path (TODO in `sheerwater.data.tahmo`), this skill will cover both cached and fresh fetches and the forecasting-skills version becomes redundant.
+
+## Variants
+
+The CLI accepts these dataset names:
+
+| Name | Per-cell aggregation |
+|---|---|
+| `tahmo` | first station only |
+| `tahmo_avg` | mean of all stations in the cell |
+
+## When to use
+
+- A task needs African in-situ rainfall observations.
+- Comparing a gridded product or forecast against station measurements over Africa.
+
+## Usage
+
+```
+uvx sheerwater@latest data fetch <name> \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip] [--agg-days 1] \
+    [--grid global0_25] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — only `precip` is supported (daily mm).
+- `--agg-days` — rolling-mean window in days (default 1).
+- `--grid` — output grid (default `global0_25`).
+
+See `uvx sheerwater@latest data fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with `precip` (mm/day) plus a companion `precip_count` (number of valid station-days in each cell). Stamped with `rhiza_source=<name>` and `sparse=True`.
+
+## Example
+
+```bash
+uvx sheerwater@latest data fetch tahmo --start 2024-01-01 --end 2024-12-31 \
+    --variable precip --output /tmp/tahmo_2024.zarr
+```

--- a/skills/tamsat-fetch/SKILL.md
+++ b/skills/tamsat-fetch/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: tamsat-fetch
+description: Fetch TAMSAT African daily rainfall (Rainfall Estimate v3.1) for a date range and write a Rhiza Envelope Zarr. Use when a task needs the TAMSAT African rainfall product as ground truth.
+license: MIT
+compatibility: Requires Python 3.12+, uv, and the `sheerwater` CLI. Underlying TAMSAT data is read from the JASMIN public archive; set GOOGLE_APPLICATION_CREDENTIALS only if accessing the private sheerwater cache.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - uv
+      env:
+        - GOOGLE_APPLICATION_CREDENTIALS
+    primaryEnv: GOOGLE_APPLICATION_CREDENTIALS
+---
+
+# tamsat-fetch
+
+TAMSAT (Tropical Applications of Meteorology using SATellite data) is a long-record African daily rainfall dataset. Sheerwater serves the v3.1 RFE (Rainfall Estimate) product from the JASMIN public archive (`gws-access.jasmin.ac.uk/public/tamsat/rfe/data_degraded/v3.1/daily/0.25/rfe1983-present_daily_0.25.v3.1.nc`).
+
+The single registered dataset name is `tamsat`. Coverage starts in 1983.
+
+## Cache vs live fetch
+
+- **Cache hit**: anonymous, fast.
+- **Cache miss**: live fetch reads the v3.1 NetCDF directly from JASMIN's public HTTP archive. No credentials needed for the live source either. Fully self-serve.
+
+## When to use
+
+- A task needs Africa-specific gridded rainfall as observations.
+- Comparing African forecasts against a region-tuned truth dataset.
+
+## Usage
+
+```
+uvx sheerwater@latest data fetch tamsat \
+    --start YYYY-MM-DD --end YYYY-MM-DD \
+    [--variable precip] [--agg-days 1] \
+    [--grid global0_25|tamsat] [--mask lsm] [--region global] \
+    --output <path.zarr>
+```
+
+### Key flags
+
+- `--variable` — only `precip` is supported (daily mm).
+- `--agg-days` — rolling-mean window in days (default 1).
+- `--grid` — output grid (default `global0_25`). Native source is 0.25°; the loader rejects grids smaller than 0.25°. Pass `--grid tamsat` to keep the native form.
+
+See `uvx sheerwater@latest data fetch --help` for the full flag list.
+
+### Output
+
+Envelope Zarr with `precip` (mm/day), dims `(time, lat, lon)`, stamped with `rhiza_source=tamsat`.
+
+## Example
+
+```bash
+uvx sheerwater@latest data fetch tamsat --start 2024-01-01 --end 2024-03-31 \
+    --region ghana --output /tmp/tamsat_ghana.zarr
+```


### PR DESCRIPTION
Add a cli for sheerwater with access to fetching data for all available data sources, forecasts, ops, and evals. 

uv run sheerwater --help   
Usage: sheerwater [OPTIONS] COMMAND [ARGS]...

  Sheerwater: weather data, forecasts, ops, and benchmarking.

  Authentication: public datasets work anonymously against sheerwater's public
  GCS bucket. Private datasets require GCS credentials via
  GOOGLE_APPLICATION_CREDENTIALS or `gcloud auth application-default login`.

  Cache management uses the `nuthatch` CLI directly (sheerwater's caches are
  backed by nuthatch).

Options:
  -h, --help  Show this message and exit.

Commands:
  data      Fetch and discover data sources (observations, reanalysis,...
  eval      Forecast verification metrics.
  forecast  Fetch and discover forecast models.
  list      Discovery: list registered datasets, forecasts, and metrics.
  ops       Spatial and temporal operations on envelope Zarr stores.